### PR TITLE
Auth-service: guard cleanup when DB is nil to prevent startup panic

### DIFF
--- a/backend/auth-service/cmd/server/main.go
+++ b/backend/auth-service/cmd/server/main.go
@@ -39,10 +39,14 @@ func main() {
 	// Initialize handlers (DB may be nil; /ready will report accordingly)
 	handler := api.NewHandler(database)
 
-	// Initialize cleanup service (runs every 30 minutes)
-	cleanupService := services.NewCleanupService(database, 30)
-	cleanupService.Start()
-	defer cleanupService.Stop()
+	// Initialize cleanup service (runs every 30 minutes) only if DB is available
+	if database != nil {
+		cleanupService := services.NewCleanupService(database, 30)
+		cleanupService.Start()
+		defer cleanupService.Stop()
+	} else {
+		log.Println("[WARN] Skipping cleanup service start; database unavailable at startup")
+	}
 
 	// Set up Gin router
 	router := setupRouter(handler)


### PR DESCRIPTION
- Start CleanupService only when DB initialized
- Avoid nil pointer deref that caused container to exit, App Runner health check failures, and 404 at /live

Once merged, I will rebuild/push auth-service image and trigger App Runner deployment to verify /live==200 promptly.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author