### PR TITLE
Terraform: fix validations by using trimspace() (trim requires 2 args)

### DIFF
--- a/terraform/app_runner/variables.tf
+++ b/terraform/app_runner/variables.tf
@@ -17,7 +17,7 @@ variable "neon_db_host" {
   type        = string
   sensitive   = true
   validation {
-    condition     = length(trim(var.neon_db_host)) > 0
+    condition     = length(trimspace(var.neon_db_host)) > 0
     error_message = "neon_db_host must be provided."
   }
 }
@@ -27,7 +27,7 @@ variable "neon_db_user" {
   type        = string
   sensitive   = true
   validation {
-    condition     = length(trim(var.neon_db_user)) > 0
+    condition     = length(trimspace(var.neon_db_user)) > 0
     error_message = "neon_db_user must be provided."
   }
 }
@@ -36,7 +36,7 @@ variable "neon_db_name" {
   description = "Database name for the Neon PostgreSQL database."
   type        = string
   validation {
-    condition     = length(trim(var.neon_db_name)) > 0
+    condition     = length(trimspace(var.neon_db_name)) > 0
     error_message = "neon_db_name must be provided."
   }
 }
@@ -46,7 +46,7 @@ variable "secret_arn_db_password" {
   type        = string
   sensitive   = true
   validation {
-    condition     = length(trim(var.secret_arn_db_password)) > 0
+    condition     = length(trimspace(var.secret_arn_db_password)) > 0
     error_message = "secret_arn_db_password is required and must be a non-empty ARN."
   }
 }
@@ -56,7 +56,7 @@ variable "secret_arn_jwt_secret" {
   type        = string
   sensitive   = true
   validation {
-    condition     = length(trim(var.secret_arn_jwt_secret)) > 0
+    condition     = length(trimspace(var.secret_arn_jwt_secret)) > 0
     error_message = "secret_arn_jwt_secret is required and must be a non-empty ARN."
   }
 }
@@ -80,14 +80,14 @@ variable "ses_from_email" {
 
 # Enable-email validation: either all three are empty (email disabled) or all three are set (email enabled)
 locals {
-  _ses_any_set = length(trim(var.ses_from_email)) > 0 || length(trim(var.secret_arn_ses_user)) > 0 || length(trim(var.secret_arn_ses_pass)) > 0
+  _ses_any_set = length(trimspace(var.ses_from_email)) > 0 || length(trimspace(var.secret_arn_ses_user)) > 0 || length(trimspace(var.secret_arn_ses_pass)) > 0
 }
 
 # Using a null_resource to host a precondition-like validation because variable blocks cannot express cross-variable conditions directly.
 resource "null_resource" "validate_email_trio" {
   lifecycle {
     precondition {
-      condition     = (local._ses_any_set == false) || (length(trim(var.ses_from_email)) > 0 && length(trim(var.secret_arn_ses_user)) > 0 && length(trim(var.secret_arn_ses_pass)) > 0)
+      condition     = (local._ses_any_set == false) || (length(trimspace(var.ses_from_email)) > 0 && length(trimspace(var.secret_arn_ses_user)) > 0 && length(trimspace(var.secret_arn_ses_pass)) > 0)
       error_message = "To enable email, set SES_FROM_EMAIL and both SES SMTP secret ARNs (user+pass). Otherwise leave all three empty."
     }
   }


### PR DESCRIPTION
Fix CI validate/apply failures caused by using trim() in variable validations and precondition. Terraform's trim() requires 2 args; use trimspace() for single-arg whitespace trimming.

Changes:
- Replace trim() with trimspace() in terraform/app_runner/variables.tf across all validations and SES trio precondition.

After merge:
- Re-run "Terraform Apply (App Runner)" workflow. It should pass validations and proceed.
