### PR TITLE
Terraform: fix secret_arns locals (invalid refs) and use trimspace() in runtime secrets

### DIFF
--- a/terraform/app_runner/apprunner.tf
+++ b/terraform/app_runner/apprunner.tf
@@ -8,14 +8,14 @@ locals {
 
   # Build a clean list of secret ARNs (skip empty values) to avoid malformed IAM policies
   secret_arns = [for v in [
-    var.secret_arn_db_password != "" ? db_secret_base         : "",
-    var.secret_arn_db_password != "" ? var.secret_arn_db_password : "",
-    var.secret_arn_jwt_secret  != "" ? jwt_secret_base        : "",
-    var.secret_arn_jwt_secret  != "" ? var.secret_arn_jwt_secret  : "",
-    var.secret_arn_ses_user    != "" ? ses_user_base          : "",
-    var.secret_arn_ses_user    != "" ? var.secret_arn_ses_user    : "",
-    var.secret_arn_ses_pass    != "" ? ses_pass_base          : "",
-    var.secret_arn_ses_pass    != "" ? var.secret_arn_ses_pass    : "",
+    length(trimspace(var.secret_arn_db_password)) > 0 ? local.db_secret_base             : "",
+    length(trimspace(var.secret_arn_db_password)) > 0 ? var.secret_arn_db_password       : "",
+    length(trimspace(var.secret_arn_jwt_secret))  > 0 ? local.jwt_secret_base            : "",
+    length(trimspace(var.secret_arn_jwt_secret))  > 0 ? var.secret_arn_jwt_secret        : "",
+    length(trimspace(var.secret_arn_ses_user))    > 0 ? local.ses_user_base              : "",
+    length(trimspace(var.secret_arn_ses_user))    > 0 ? var.secret_arn_ses_user          : "",
+    length(trimspace(var.secret_arn_ses_pass))    > 0 ? local.ses_pass_base              : "",
+    length(trimspace(var.secret_arn_ses_pass))    > 0 ? var.secret_arn_ses_pass          : "",
   ] : v if v != ""]
 
   # Ensure we always use Neon connection pooler. If the provided host already contains
@@ -139,9 +139,9 @@ resource "aws_apprunner_service" "main_services" {
         } : {})
         runtime_environment_secrets = merge(
           {},
-          length(trim(var.secret_arn_db_password)) > 0 ? { DB_PASSWORD = var.secret_arn_db_password } : {},
-          length(trim(var.secret_arn_jwt_secret))  > 0 ? { JWT_SECRET  = var.secret_arn_jwt_secret  } : {},
-          (length(trim(var.secret_arn_ses_user)) > 0 && length(trim(var.secret_arn_ses_pass)) > 0) ? {
+          length(trimspace(var.secret_arn_db_password)) > 0 ? { DB_PASSWORD = var.secret_arn_db_password } : {},
+          length(trimspace(var.secret_arn_jwt_secret))  > 0 ? { JWT_SECRET  = var.secret_arn_jwt_secret  } : {},
+          (length(trimspace(var.secret_arn_ses_user)) > 0 && length(trimspace(var.secret_arn_ses_pass)) > 0) ? {
             AWS_ACCESS_KEY_ID     = var.secret_arn_ses_user
             AWS_SECRET_ACCESS_KEY = var.secret_arn_ses_pass
           } : {}


### PR DESCRIPTION
Fixes current CI validate/apply errors:
- Locals secret_arns used unqualified symbols (db_secret_base, etc.). In locals, we must reference via local.<name>. Updated all these references accordingly and guard with length(trimspace(...)) checks.
- runtime_environment_secrets still used trim(); replaced with trimspace() to match Terraform's single-arg whitespace trimming.

After merge:
- Re-run Terraform Apply (App Runner). Validate should pass; apply should proceed.
