### PR TITLE
CI: dynamic imports (no hardcoded ARNs) + ensure IAM/S3 resources imported

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -21,17 +21,15 @@ jobs:
     env:
       TF_IN_AUTOMATION: true
       TF_INPUT: false
-      # Map GitHub Secrets to Terraform variables via TF_VAR_*
       TF_VAR_aws_region: ${{ secrets.AWS_REGION }}
       TF_VAR_project: madeinworld
       TF_VAR_neon_db_host: ${{ secrets.NEON_DB_HOST }}
       TF_VAR_neon_db_user: ${{ secrets.NEON_DB_USER }}
       TF_VAR_neon_db_name: ${{ secrets.NEON_DB_NAME }}
-      # Support both old and new secret names
       TF_VAR_secret_arn_db_password: ${{ secrets.SECRET_ARN_DB_PASSWORD || secrets.DB_SECRET_ARN }}
       TF_VAR_secret_arn_jwt_secret: ${{ secrets.SECRET_ARN_JWT_SECRET || secrets.JWT_SECRET_ARN }}
       TF_VAR_secret_arn_ses_user: ${{ secrets.SECRET_ARN_SES_USER || secrets.SES_SMTP_USER_ARN }}
-      TF_VAR_secret_arn_ses_pass: ${{ secrets.SECRET_ARN_SES_PASS || secrets.SES_SMTP_PASS_ARN }}
+      TF_VAR_secret_arn_ses_pass: ${{ secrets.SECRET_ARN_SES_PASS || secrets.SES_SMTP_USER_ARN }}
       TF_VAR_ses_from_email: ${{ secrets.SES_FROM_EMAIL }}
       TF_VAR_canary_schedule_expression: ${{ secrets.CANARY_SCHEDULE_EXPRESSION || 'rate(2 minutes)' }}
 
@@ -61,105 +59,53 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
-      - name: Import existing App Runner services
+      - name: Import existing infra dynamically
         run: |
           set -e
-          echo "=== Importing existing App Runner services ==="
+          echo "=== Importing existing infra dynamically ==="
 
-          # Function to safely import resources
           safe_import() {
-            local resource_addr="$1"
-            local resource_id="$2"
-
-            echo "Checking if $resource_addr exists in state..."
-            if terraform state list | grep -q "^${resource_addr}$"; then
-              echo "✓ $resource_addr already in state"
-              return 0
-            fi
-
-            echo "Attempting to import $resource_addr..."
-            if terraform import -input=false -no-color "$resource_addr" "$resource_id" 2>/dev/null; then
-              echo "✓ Successfully imported $resource_addr"
-            else
-              echo "⚠ Failed to import $resource_addr (resource may not exist)"
-            fi
+            local addr="$1"; local id="$2"
+            if [ -z "$id" ] || [ "$id" = "null" ] || [ "$id" = "None" ]; then
+              echo "skip: empty id for $addr"; return 0; fi
+            if terraform state list | grep -q "^${addr}$"; then
+              echo "ok: already in state $addr"; return 0; fi
+            echo "import: $addr <- $id"
+            terraform import -input=false -no-color "$addr" "$id" || true
           }
 
-          # Get current AWS account and region
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           REGION="${AWS_REGION:-eu-central-1}"
 
-          # Import ECR repositories (id format: <name>)
+          # Import ECR repos
           for NAME in auth-service catalog-service order-service user-service; do
-            safe_import "aws_ecr_repository.service_repos[\"$NAME\"]" "madeinworld/$NAME" || true
+            safe_import "aws_ecr_repository.service_repos[\"$NAME\"]" "madeinworld/$NAME"
           done
 
-          # Import App Runner services using their ARNs
-          safe_import "aws_apprunner_service.main_services[\"auth-service\"]" \
-            "arn:aws:apprunner:${REGION}:${ACCOUNT_ID}:service/madeinworld-auth-service-dev/df75a50d25a14060907df4d0353b0aa5"
+          # Import S3 bucket (canary artifacts)
+          safe_import aws_s3_bucket.synthetics_artifacts "madeinworld-synthetics-artifacts"
 
-          safe_import "aws_apprunner_service.main_services[\"catalog-service\"]" \
-            "arn:aws:apprunner:${REGION}:${ACCOUNT_ID}:service/madeinworld-catalog-service-dev/29f7cd156cd94c8eab29a95871958c05"
+          # Import IAM roles used as data sources (to avoid drift destroy)
+          safe_import aws_iam_role.apprunner_ecr_access_role   "madeinworld-apprunner-ecr-access-role"
+          safe_import aws_iam_role.apprunner_instance_role     "madeinworld-apprunner-instance-role"
+          safe_import aws_iam_role.synthetics_role             "madeinworld-synthetics-role"
 
-          safe_import "aws_apprunner_service.main_services[\"order-service\"]" \
-            "arn:aws:apprunner:${REGION}:${ACCOUNT_ID}:service/madeinworld-order-service-dev/5d18df9cb7ba4ea9b0d1a467aa07833b"
+          # Import App Runner services by discovering ARNs dynamically (no hardcoded IDs)
+          for svc in auth-service catalog-service order-service user-service; do
+            svc_name="madeinworld-$svc-dev"
+            arn=$(aws apprunner list-services --query "ServiceSummaryList[?ServiceName=='${svc_name}'].ServiceArn | [0]" --output text 2>/dev/null || echo "")
+            if [ -n "$arn" ] && [ "$arn" != "None" ] && [ "$arn" != "null" ]; then
+              safe_import "aws_apprunner_service.main_services[\"$svc\"]" "$arn"
+            else
+              echo "info: App Runner service $svc_name not found; will be created if defined"
+            fi
+          done
 
-          safe_import "aws_apprunner_service.main_services[\"user-service\"]" \
-            "arn:aws:apprunner:${REGION}:${ACCOUNT_ID}:service/madeinworld-user-service-dev/6ac7e53e5d1449b6930fe114bdcef6bc"
-
-          echo "=== Import completed ==="
-          echo "Current state:"
-          terraform state list | grep apprunner_service || echo "No App Runner services in state"
+          echo "=== Import complete ==="
+          terraform state list || true
 
       - name: Terraform Plan
         run: terraform plan -input=false -no-color
 
-      - name: Terraform Apply (with conflict handling)
-        run: |
-          set -e
-          echo "=== Applying Terraform configuration ==="
-
-          # First attempt - normal apply
-          if terraform apply -input=false -auto-approve -no-color; then
-            echo "✓ Terraform apply succeeded"
-            exit 0
-          fi
-
-          echo "⚠ First apply failed, checking for App Runner conflicts..."
-
-          # If apply failed due to existing services, try to import them dynamically
-          echo "Attempting to discover and import existing App Runner services..."
-
-          for service_name in madeinworld-auth-service-dev madeinworld-catalog-service-dev madeinworld-order-service-dev madeinworld-user-service-dev; do
-            echo "Checking for service: $service_name"
-
-            # Get service ARN if it exists
-            service_arn=$(aws apprunner list-services --query "ServiceSummaryList[?ServiceName=='$service_name'].ServiceArn | [0]" --output text 2>/dev/null || echo "")
-
-            if [ -n "$service_arn" ] && [ "$service_arn" != "None" ] && [ "$service_arn" != "null" ]; then
-              echo "Found existing service: $service_arn"
-
-              # Determine the Terraform resource name
-              case "$service_name" in
-                "madeinworld-auth-service-dev")
-                  tf_resource="aws_apprunner_service.main_services[\"auth-service\"]"
-                  ;;
-                "madeinworld-catalog-service-dev")
-                  tf_resource="aws_apprunner_service.main_services[\"catalog-service\"]"
-                  ;;
-                "madeinworld-order-service-dev")
-                  tf_resource="aws_apprunner_service.main_services[\"order-service\"]"
-                  ;;
-                "madeinworld-user-service-dev")
-                  tf_resource="aws_apprunner_service.main_services[\"user-service\"]"
-                  ;;
-              esac
-
-              # Try to import
-              echo "Importing $tf_resource..."
-              terraform import -input=false -no-color "$tf_resource" "$service_arn" || echo "Import failed for $tf_resource"
-            fi
-          done
-
-          echo "Retrying Terraform apply after imports..."
-          terraform apply -input=false -auto-approve -no-color
+      - name: Terraform Apply
+        run: terraform apply -input=false -auto-approve -no-color


### PR DESCRIPTION
- Remove hardcoded App Runner service ARNs in workflow; discover ARNs dynamically via aws apprunner list-services
- Import ECR repos, S3 bucket, and IAM roles used by data sources to prevent drift destroys
- Keep S3 remote backend init with -backend-config flags

This eliminates brittleness flagged by Cursor bot and addresses current failures where IAM/S3 resources are not in state.

After merge:
1) Pull main
2) terraform init -migrate-state with your backend-config (if not done)
3) terraform apply locally to reconcile any drift
4) Re-run the Actions workflow; it should succeed (no +create for existing App Runner services, no IAM destroys)
