### PR TITLE
Terraform: manage App Runner IAM resources + fix SES fallback + dynamic imports

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -29,7 +29,7 @@ jobs:
       TF_VAR_secret_arn_db_password: ${{ secrets.SECRET_ARN_DB_PASSWORD || secrets.DB_SECRET_ARN }}
       TF_VAR_secret_arn_jwt_secret: ${{ secrets.SECRET_ARN_JWT_SECRET || secrets.JWT_SECRET_ARN }}
       TF_VAR_secret_arn_ses_user: ${{ secrets.SECRET_ARN_SES_USER || secrets.SES_SMTP_USER_ARN }}
-      TF_VAR_secret_arn_ses_pass: ${{ secrets.SECRET_ARN_SES_PASS || secrets.SES_SMTP_USER_ARN }}
+      TF_VAR_secret_arn_ses_pass: ${{ secrets.SECRET_ARN_SES_PASS || secrets.SES_SMTP_PASS_ARN }}
       TF_VAR_ses_from_email: ${{ secrets.SES_FROM_EMAIL }}
       TF_VAR_canary_schedule_expression: ${{ secrets.CANARY_SCHEDULE_EXPRESSION || 'rate(2 minutes)' }}
 
@@ -85,10 +85,10 @@ jobs:
           # Import S3 bucket (canary artifacts)
           safe_import aws_s3_bucket.synthetics_artifacts "madeinworld-synthetics-artifacts"
 
-          # Import IAM roles used as data sources (to avoid drift destroy)
+          # Import IAM roles and policy (managed in TF)
           safe_import aws_iam_role.apprunner_ecr_access_role   "madeinworld-apprunner-ecr-access-role"
           safe_import aws_iam_role.apprunner_instance_role     "madeinworld-apprunner-instance-role"
-          safe_import aws_iam_role.synthetics_role             "madeinworld-synthetics-role"
+          safe_import aws_iam_policy.apprunner_secrets_policy  "arn:aws:iam::${ACCOUNT_ID}:policy/madeinworld-apprunner-secrets-policy"
 
           # Import App Runner services by discovering ARNs dynamically (no hardcoded IDs)
           for svc in auth-service catalog-service order-service user-service; do

--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -1,0 +1,68 @@
+# terraform/app_runner/iam.tf
+
+# Current account
+data "aws_caller_identity" "current" {}
+
+# App Runner ECR access role (assumed by App Runner to pull from ECR)
+resource "aws_iam_role" "apprunner_ecr_access_role" {
+  name = "${var.project}-apprunner-ecr-access-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = { Service = "build.apprunner.amazonaws.com" },
+        Action   = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# Attach AWS managed policy for ECR access
+resource "aws_iam_role_policy_attachment" "apprunner_ecr_access_managed" {
+  role       = aws_iam_role.apprunner_ecr_access_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
+}
+
+# Instance role for running App Runner service (to read Secrets Manager)
+resource "aws_iam_role" "apprunner_instance_role" {
+  name = "${var.project}-apprunner-instance-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = { Service = "tasks.apprunner.amazonaws.com" },
+        Action   = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# Construct policy document granting read access to specified secret ARNs
+data "aws_iam_policy_document" "apprunner_secrets_doc" {
+  dynamic "statement" {
+    for_each = toset(local.secret_arns)
+    content {
+      sid     = "AllowSecret${replace(statement.value, ":", "")}" 
+      effect  = "Allow"
+      actions = ["secretsmanager:GetSecretValue"]
+      resources = [statement.value]
+    }
+  }
+}
+
+# Customer managed policy with least-privilege secret access
+resource "aws_iam_policy" "apprunner_secrets_policy" {
+  name        = "${var.project}-apprunner-secrets-policy"
+  description = "App Runner instance role can read necessary secrets"
+  policy      = data.aws_iam_policy_document.apprunner_secrets_doc.json
+}
+
+# Attach secrets policy to instance role
+resource "aws_iam_role_policy_attachment" "apprunner_secrets_access" {
+  role       = aws_iam_role.apprunner_instance_role.name
+  policy_arn = aws_iam_policy.apprunner_secrets_policy.arn
+}


### PR DESCRIPTION
- Introduce terraform/app_runner/iam.tf to manage:
  - aws_iam_role.apprunner_ecr_access_role (w/ assume role policy)
  - aws_iam_role_policy_attachment.apprunner_ecr_access_managed
  - aws_iam_role.apprunner_instance_role (w/ assume role policy)
  - aws_iam_policy.apprunner_secrets_policy from a generated policy doc over provided secret ARNs
  - aws_iam_role_policy_attachment.apprunner_secrets_access
- Refactor apprunner.tf to reference the managed IAM resources (no more data sources for these)
- CI: fix SES password fallback (use SES_SMTP_PASS_ARN, not SES_SMTP_USER_ARN)
- CI: dynamic imports now also import IAM policy and roles, ECR repos, S3 bucket, and App Runner services via discovery

This eliminates the drift that planned destroys the three critical IAM resources and removes brittle, hardcoded ARNs in CI.
