### PR TITLE
Reduce CloudWatch/Neon cost: switch canary to /live + hourly; lower DB MinConns

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -31,7 +31,7 @@ jobs:
       TF_VAR_secret_arn_ses_user: ${{ secrets.SECRET_ARN_SES_USER || secrets.SES_SMTP_USER_ARN }}
       TF_VAR_secret_arn_ses_pass: ${{ secrets.SECRET_ARN_SES_PASS || secrets.SES_SMTP_PASS_ARN }}
       TF_VAR_ses_from_email: ${{ secrets.SES_FROM_EMAIL }}
-      TF_VAR_canary_schedule_expression: ${{ secrets.CANARY_SCHEDULE_EXPRESSION || 'rate(2 minutes)' }}
+      TF_VAR_canary_schedule_expression: ${{ secrets.CANARY_SCHEDULE_EXPRESSION || 'rate(1 hour)' }}
 
     steps:
       - name: Checkout

--- a/backend/auth-service/internal/db/database.go
+++ b/backend/auth-service/internal/db/database.go
@@ -71,9 +71,9 @@ func NewDatabaseWithRetry(maxRetries int, initialDelay time.Duration) (*Database
 
 	// Set pool settings
 	poolConfig.MaxConns = 30
-	poolConfig.MinConns = 5
+	poolConfig.MinConns = 0
 	poolConfig.MaxConnLifetime = time.Hour
-	poolConfig.MaxConnIdleTime = time.Minute * 30
+	poolConfig.MaxConnIdleTime = 5 * time.Minute
 	// Prefer simple protocol (no prepared statements) to be PgBouncer/Neon pooler friendly
 	poolConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 

--- a/backend/catalog-service/internal/db/database.go
+++ b/backend/catalog-service/internal/db/database.go
@@ -69,9 +69,9 @@ func NewDatabaseWithRetry(maxRetries int, initialDelay time.Duration) (*Database
 
 	// Set pool settings
 	poolConfig.MaxConns = 30
-	poolConfig.MinConns = 5
+	poolConfig.MinConns = 0
 	poolConfig.MaxConnLifetime = time.Hour
-	poolConfig.MaxConnIdleTime = time.Minute * 30
+	poolConfig.MaxConnIdleTime = 5 * time.Minute
 
 	origHost := poolConfig.ConnConfig.Host
 

--- a/backend/order-service/internal/db/database.go
+++ b/backend/order-service/internal/db/database.go
@@ -68,9 +68,9 @@ func NewDatabaseWithRetry(maxRetries int, initialDelay time.Duration) (*Database
 
 	// Set pool settings
 	poolConfig.MaxConns = 30
-	poolConfig.MinConns = 5
+	poolConfig.MinConns = 0
 	poolConfig.MaxConnLifetime = time.Hour
-	poolConfig.MaxConnIdleTime = time.Minute * 30
+	poolConfig.MaxConnIdleTime = 5 * time.Minute
 	// Prefer simple protocol to be Neon pooler friendly
 	poolConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 

--- a/terraform/app_runner/canary.tf
+++ b/terraform/app_runner/canary.tf
@@ -43,7 +43,7 @@ resource "aws_synthetics_canary" "auth_ready" {
 
   run_config {
     environment_variables = {
-      TARGET_URL = "${aws_apprunner_service.main_services["auth-service"].service_url}/ready"
+      TARGET_URL = "${aws_apprunner_service.main_services["auth-service"].service_url}/live"
     }
   }
 


### PR DESCRIPTION
- Switch CloudWatch Synthetics canary target to /live (no DB ping)
- Default schedule to rate(1 hour) via workflow fallback
- Reduce pgx MinConns to 0 and shorten idle timeouts so Neon can autosuspend

This should materially reduce CloudWatch Logs/Synthetics and Neon compute usage without affecting functionality (App Runner health checks use /live).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author