### PR TITLE
ci: remove dynamic import; keep App Runner applies and log retention

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -78,50 +78,7 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
-      - name: Import existing infra dynamically
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-        run: |
-          set -e
-          echo "=== Importing existing infra dynamically ==="
 
-          safe_import() {
-            local addr="$1"; local id="$2"
-            if [ -z "$id" ] || [ "$id" = "null" ] || [ "$id" = "None" ]; then
-              echo "skip: empty id for $addr"; return 0; fi
-            if terraform state list | grep -q "^${addr}$"; then
-              echo "ok: already in state $addr"; return 0; fi
-            echo "import: $addr <- $id"
-            terraform import -input=false -no-color "$addr" "$id" || true
-          }
-
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-          REGION="${AWS_REGION:-eu-central-1}"
-
-          # Import ECR repos
-          for NAME in auth-service catalog-service order-service user-service; do
-            safe_import "aws_ecr_repository.service_repos[\"$NAME\"]" "madeinworld/$NAME"
-          done
-
-          # S3 canary artifacts bucket is a data source in TF; do not import as a resource
-          # Import IAM roles and policy (managed in TF)
-          safe_import aws_iam_role.apprunner_ecr_access_role   "madeinworld-apprunner-ecr-access-role"
-          safe_import aws_iam_role.apprunner_instance_role     "madeinworld-apprunner-instance-role"
-          safe_import aws_iam_policy.apprunner_secrets_policy  "arn:aws:iam::${ACCOUNT_ID}:policy/madeinworld-apprunner-secrets-policy"
-
-          # Import App Runner services by discovering ARNs dynamically (no hardcoded IDs)
-          for svc in auth-service catalog-service order-service user-service; do
-            svc_name="madeinworld-$svc-dev"
-            arn=$(aws apprunner list-services --query "ServiceSummaryList[?ServiceName=='${svc_name}'].ServiceArn | [0]" --output text 2>/dev/null || echo "")
-            if [ -n "$arn" ] && [ "$arn" != "None" ] && [ "$arn" != "null" ]; then
-              safe_import "aws_apprunner_service.main_services[\"$svc\"]" "$arn"
-            else
-              echo "info: App Runner service $svc_name not found; will be created if defined"
-            fi
-          done
-
-          echo "=== Import complete ==="
-          terraform state list || true
 
       - name: Terraform Plan
         run: terraform plan -input=false -no-color -parallelism=1


### PR DESCRIPTION
This PR cleans up the Terraform App Runner workflow:

- Removes the dynamic "Import existing infra" step that produced noisy "Resource already managed" messages and masked errors.
- Keeps the targeted App Runner applies for auth/catalog/order/user (serialization still preserved).
- Keeps a final full `terraform apply`.
- Preserves the log retention step. With the IAM updates you just made (DescribeLogGroups + PutRetentionPolicy), this should now pass.

Benefits:
- Less noise and fewer false-positive errors in logs.
- Faster, clearer runs.
- Fully managed state without ad-hoc imports every run.

After merging, re-run the workflow. It should go fully green now that IAM has logs permissions.