### PR TITLE
ops: fix verify workflow (describe-canaries + debug listing)

### DIFF
--- a/.github/workflows/verify-cloudwatch-synthetics.yml
+++ b/.github/workflows/verify-cloudwatch-synthetics.yml
@@ -20,6 +20,14 @@ jobs:
           role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: List canaries (debug)
+        env:
+          REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set -euo pipefail
+          echo "Listing canaries in $REGION"
+          aws synthetics describe-canaries --region "$REGION" --query 'Canaries[].Name' --output text || true
+
       - name: Verify canary exists and is scheduled daily
         env:
           REGION: ${{ secrets.AWS_REGION }}
@@ -28,7 +36,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Verifying $EXPECTED_NAME in $REGION with schedule $EXPECTED_EXPR"
-          FOUND=$(aws synthetics list-canaries --region "$REGION" --query "Canaries[?Name=='$EXPECTED_NAME'].Name" --output text || true)
+          FOUND=$(aws synthetics describe-canaries --region "$REGION" --query "Canaries[?Name=='$EXPECTED_NAME'].Name" --output text || true)
           if [ -z "$FOUND" ] || [ "$FOUND" = "None" ]; then
             echo "ERROR: Expected canary $EXPECTED_NAME not found"
             exit 1


### PR DESCRIPTION
Replaces deprecated/invalid `list-canaries` call with `describe-canaries` and adds a debug step to list canaries in the region. This is a clean PR from current main to avoid previous merge conflicts.