### PR TITLE
terraform: use subscriber_email_addresses in budget notifications (fix validate)

### DIFF
--- a/terraform/app_runner/anomaly_detection.tf
+++ b/terraform/app_runner/anomaly_detection.tf
@@ -1,0 +1,33 @@
+// AWS Cost Anomaly Detection for Amazon CloudWatch service
+// Note: Cost Explorer/Anomaly Detection API is in us-east-1
+
+resource "aws_ce_anomaly_monitor" "cloudwatch_service" {
+  provider          = aws.us_east_1
+  name              = "cloudwatch-service-monitor"
+  monitor_type      = "DIMENSIONAL"
+  monitor_dimension = "SERVICE"
+}
+
+resource "aws_ce_anomaly_subscription" "cloudwatch_alerts" {
+  provider  = aws.us_east_1
+  name      = "cloudwatch-anomaly-alerts"
+  frequency = "DAILY"
+
+  monitor_arn_list = [aws_ce_anomaly_monitor.cloudwatch_service.arn]
+
+  threshold_expression {
+    and {
+      dimension {
+        key           = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
+        values        = ["5"] // USD absolute daily impact
+        match_options = ["GREATER_THAN_OR_EQUAL"]
+      }
+    }
+  }
+
+  subscriber {
+    type    = "EMAIL"
+    address = "expotobsrl@gmail.com"
+  }
+}
+

--- a/terraform/app_runner/budgets.tf
+++ b/terraform/app_runner/budgets.tf
@@ -21,10 +21,7 @@ resource "aws_budgets_budget" "cloudwatch_monthly" {
     threshold           = 80
     threshold_type      = "PERCENTAGE"
     notification_type   = "FORECASTED"
-    subscriber {
-      subscription_type = "EMAIL"
-      address           = "expotobsrl@gmail.com"
-    }
+    subscriber_email_addresses = ["expotobsrl@gmail.com"]
   }
 
   notification {
@@ -32,10 +29,7 @@ resource "aws_budgets_budget" "cloudwatch_monthly" {
     threshold           = 80
     threshold_type      = "PERCENTAGE"
     notification_type   = "ACTUAL"
-    subscriber {
-      subscription_type = "EMAIL"
-      address           = "expotobsrl@gmail.com"
-    }
+    subscriber_email_addresses = ["expotobsrl@gmail.com"]
   }
 }
 

--- a/terraform/app_runner/budgets.tf
+++ b/terraform/app_runner/budgets.tf
@@ -11,8 +11,9 @@ resource "aws_budgets_budget" "cloudwatch_monthly" {
 
   time_unit = "MONTHLY"
 
-  cost_filters = {
-    Service = ["Amazon CloudWatch"]
+  cost_filter {
+    name   = "Service"
+    values = ["Amazon CloudWatch"]
   }
 
   notification {
@@ -20,7 +21,10 @@ resource "aws_budgets_budget" "cloudwatch_monthly" {
     threshold           = 80
     threshold_type      = "PERCENTAGE"
     notification_type   = "FORECASTED"
-    subscriber_email_addresses = ["expotobsrl@gmail.com"]
+    subscriber {
+      subscription_type = "EMAIL"
+      address           = "expotobsrl@gmail.com"
+    }
   }
 
   notification {
@@ -28,7 +32,10 @@ resource "aws_budgets_budget" "cloudwatch_monthly" {
     threshold           = 80
     threshold_type      = "PERCENTAGE"
     notification_type   = "ACTUAL"
-    subscriber_email_addresses = ["expotobsrl@gmail.com"]
+    subscriber {
+      subscription_type = "EMAIL"
+      address           = "expotobsrl@gmail.com"
+    }
   }
 }
 


### PR DESCRIPTION
Fixes Terraform Validate errors by reverting to the supported notification schema in aws_budgets_budget for provider v5.

- Keep cost_filter block for Service = "Amazon CloudWatch"
- Use `subscriber_email_addresses = ["expotobsrl@gmail.com"]` in both notification blocks

After merge, Terraform Apply should proceed and create/update the CloudWatch monthly budget. Anomaly Detection resources are unaffected.