### PR TITLE
terraform/workflow: reuse existing CE SERVICE anomaly monitor to avoid limit; auto-detect in CI

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -63,7 +63,6 @@ jobs:
 
 
 
-
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
@@ -84,7 +83,19 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
-
+      - name: Detect existing CE Service monitor (sets TF_VAR_ce_monitor_arn if found)
+        shell: bash
+        run: |
+          set -e
+          ARN=$(aws ce describe-anomaly-monitors --monitor-types DIMENSIONAL --max-results 100 \
+            --query "AnomalyMonitors[?MonitorType=='DIMENSIONAL' && MonitorDimension=='SERVICE'].MonitorArn | [0]" \
+            --output text || true)
+          if [ -n "$ARN" ] && [ "$ARN" != "None" ]; then
+            echo "Found existing CE SERVICE monitor: $ARN"
+            echo "TF_VAR_ce_monitor_arn=$ARN" >> $GITHUB_ENV
+          else
+            echo "No existing CE SERVICE monitor found; Terraform will create one."
+          fi
 
       - name: Terraform Plan
         run: terraform plan -input=false -no-color -parallelism=1 -lock-timeout=5m

--- a/terraform/app_runner/anomaly_detection.tf
+++ b/terraform/app_runner/anomaly_detection.tf
@@ -1,11 +1,18 @@
 // AWS Cost Anomaly Detection for Amazon CloudWatch service
 // Note: Cost Explorer/Anomaly Detection API is in us-east-1
 
+# If an existing DIMENSIONAL SERVICE monitor ARN is provided, skip creating a new monitor
 resource "aws_ce_anomaly_monitor" "cloudwatch_service" {
+  count             = var.ce_monitor_arn == "" ? 1 : 0
   provider          = aws.us_east_1
   name              = "cloudwatch-service-monitor"
   monitor_type      = "DIMENSIONAL"
   monitor_dimension = "SERVICE"
+}
+
+# Resolve the monitor ARN (existing via variable or newly created by this stack)
+locals {
+  resolved_ce_monitor_arn = var.ce_monitor_arn != "" ? var.ce_monitor_arn : (length(aws_ce_anomaly_monitor.cloudwatch_service) > 0 ? aws_ce_anomaly_monitor.cloudwatch_service[0].arn : "")
 }
 
 resource "aws_ce_anomaly_subscription" "cloudwatch_alerts" {
@@ -13,7 +20,7 @@ resource "aws_ce_anomaly_subscription" "cloudwatch_alerts" {
   name      = "cloudwatch-anomaly-alerts"
   frequency = "DAILY"
 
-  monitor_arn_list = [aws_ce_anomaly_monitor.cloudwatch_service.arn]
+  monitor_arn_list = [local.resolved_ce_monitor_arn]
 
   threshold_expression {
     and {
@@ -30,4 +37,3 @@ resource "aws_ce_anomaly_subscription" "cloudwatch_alerts" {
     address = "expotobsrl@gmail.com"
   }
 }
-

--- a/terraform/app_runner/variables.tf
+++ b/terraform/app_runner/variables.tf
@@ -92,3 +92,11 @@ resource "null_resource" "validate_email_trio" {
     }
   }
 }
+
+# Optional: Use an existing Cost Explorer DIMENSIONAL SERVICE anomaly monitor by ARN
+# If empty, Terraform will attempt to create a new monitor (subject to AWS account limits)
+variable "ce_monitor_arn" {
+  description = "Existing Cost Explorer anomaly monitor ARN to use (DIMENSIONAL SERVICE). Leave empty to create one."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Summary:
- Terraform: make `aws_ce_anomaly_monitor` conditional. If `var.ce_monitor_arn` is provided, skip creation and use it. Otherwise, create a monitor as before.
- Add `ce_monitor_arn` variable in `terraform/app_runner/variables.tf`.
- CI: before plan/apply, detect an existing DIMENSIONAL SERVICE monitor via AWS CLI and export `TF_VAR_ce_monitor_arn` so Terraform reuses it. This avoids the `ValidationException: Limit exceeded on dimensional spend monitor creation` when an account-wide monitor already exists.

Files changed:
- terraform/app_runner/anomaly_detection.tf
- terraform/app_runner/variables.tf
- .github/workflows/terraform-app-runner-apply.yml

After merge:
- Re-run "Terraform Apply (App Runner)". It will either reuse the existing monitor (and only create the subscription) or create a new monitor if none exists.
