### PR TITLE
workflow: fix CE monitor detection to use get-anomaly-monitors in us-east-1

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -87,10 +87,10 @@ jobs:
         shell: bash
         run: |
           set -e
-          ARN=$(aws ce describe-anomaly-monitors --monitor-types DIMENSIONAL --max-results 100 --region us-east-1 \
+          ARN=$(aws ce get-anomaly-monitors --monitor-types DIMENSIONAL --max-results 100 --region us-east-1 \
             --query "AnomalyMonitors[?MonitorType=='DIMENSIONAL' && MonitorDimension=='SERVICE'].MonitorArn | [0]" \
             --output text || true)
-          echo "Describe monitors returned: $ARN"
+          echo "Get monitors returned: $ARN"
           if [ -n "$ARN" ] && [ "$ARN" != "None" ]; then
             echo "Found existing CE SERVICE monitor: $ARN"
             echo "TF_VAR_ce_monitor_arn=$ARN" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes the detection step so it uses `aws ce get-anomaly-monitors` (the correct CE CLI command) and forces `--region us-east-1`.

This ensures `TF_VAR_ce_monitor_arn` is set when an account-wide DIMENSIONAL SERVICE monitor already exists, so Terraform reuses it instead of trying to create a new one (which hits the service limit).

After merge: re-run "Terraform Apply (App Runner)".