### PR TITLE
Fix: don’t create CE monitor by default; correct CLI; avoid DB pings in health checks

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -58,6 +58,7 @@ jobs:
           echo "TF_VAR_ses_from_email=${{ secrets.SES_FROM_EMAIL }}" >> $GITHUB_ENV
           # Force a safe daily schedule regardless of org/repo secrets to avoid accidental cost spikes
           echo "TF_VAR_canary_schedule_expression=cron(0 0 * * ? *)" >> $GITHUB_ENV
+          echo "TF_VAR_create_ce_anomaly_monitor=false" >> $GITHUB_ENV
 
 
 
@@ -87,15 +88,16 @@ jobs:
         shell: bash
         run: |
           set -e
-          ARN=$(aws ce describe-anomaly-monitors --monitor-types DIMENSIONAL --max-results 100 --region us-east-1 \
+          ARN=$(aws ce get-anomaly-monitors --monitor-types DIMENSIONAL --max-results 100 --region us-east-1 \
             --query "AnomalyMonitors[?MonitorType=='DIMENSIONAL' && MonitorDimension=='SERVICE'].MonitorArn | [0]" \
             --output text || true)
-          echo "Describe monitors returned: $ARN"
+          echo "Get monitors returned: $ARN"
           if [ -n "$ARN" ] && [ "$ARN" != "None" ]; then
             echo "Found existing CE SERVICE monitor: $ARN"
             echo "TF_VAR_ce_monitor_arn=$ARN" >> $GITHUB_ENV
           else
-            echo "No existing CE SERVICE monitor found; Terraform will create one."
+            echo "No existing CE SERVICE monitor found; Terraform will NOT create one by default."
+            echo "TF_VAR_create_ce_anomaly_monitor=false" >> $GITHUB_ENV
           fi
 
       - name: Terraform Plan

--- a/backend/catalog-service/Dockerfile
+++ b/backend/catalog-service/Dockerfile
@@ -61,9 +61,9 @@ USER appuser
 # Expose port 8080
 EXPOSE 8080
 
-# Health check
+# Health check (liveness-only, avoid DB ping)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/live || exit 1
 
 # Run the application
 CMD ["./catalog-service"]

--- a/backend/order-service/Dockerfile
+++ b/backend/order-service/Dockerfile
@@ -61,9 +61,9 @@ USER appuser
 # Expose port 8082
 EXPOSE 8082
 
-# Health check
+# Health check (liveness-only, avoid DB ping)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8082/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8082/live || exit 1
 
 # Run the application
 CMD ["./order-service"]

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -61,9 +61,9 @@ USER appuser
 # Expose port 8083 (user-service default when USER_PORT is unset)
 EXPOSE 8083
 
-# Health check
+# Health check (liveness-only, avoid DB ping)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8083/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8083/live || exit 1
 
 # Run the application
 CMD ["./user-service"]

--- a/terraform/app_runner/anomaly_detection.tf
+++ b/terraform/app_runner/anomaly_detection.tf
@@ -1,9 +1,10 @@
 // AWS Cost Anomaly Detection for Amazon CloudWatch service
 // Note: Cost Explorer/Anomaly Detection API is in us-east-1
 
-# If an existing DIMENSIONAL SERVICE monitor ARN is provided, skip creating a new monitor
+# If an existing DIMENSIONAL SERVICE monitor ARN is provided, skip creating a new monitor.
+# Only create when explicitly enabled to avoid hitting account-wide limits.
 resource "aws_ce_anomaly_monitor" "cloudwatch_service" {
-  count             = var.ce_monitor_arn == "" ? 1 : 0
+  count             = (var.create_ce_anomaly_monitor && var.ce_monitor_arn == "") ? 1 : 0
   provider          = aws.us_east_1
   name              = "cloudwatch-service-monitor"
   monitor_type      = "DIMENSIONAL"
@@ -15,7 +16,9 @@ locals {
   resolved_ce_monitor_arn = var.ce_monitor_arn != "" ? var.ce_monitor_arn : (length(aws_ce_anomaly_monitor.cloudwatch_service) > 0 ? aws_ce_anomaly_monitor.cloudwatch_service[0].arn : "")
 }
 
+# Create subscription only when a monitor ARN is available
 resource "aws_ce_anomaly_subscription" "cloudwatch_alerts" {
+  count     = local.resolved_ce_monitor_arn != "" ? 1 : 0
   provider  = aws.us_east_1
   name      = "cloudwatch-anomaly-alerts"
   frequency = "DAILY"

--- a/terraform/app_runner/variables.tf
+++ b/terraform/app_runner/variables.tf
@@ -94,9 +94,17 @@ resource "null_resource" "validate_email_trio" {
 }
 
 # Optional: Use an existing Cost Explorer DIMENSIONAL SERVICE anomaly monitor by ARN
-# If empty, Terraform will attempt to create a new monitor (subject to AWS account limits)
+# By default, we DO NOT create a new monitor to avoid hitting account limits.
 variable "ce_monitor_arn" {
-  description = "Existing Cost Explorer anomaly monitor ARN to use (DIMENSIONAL SERVICE). Leave empty to create one."
+  description = "Existing Cost Explorer anomaly monitor ARN to use (DIMENSIONAL SERVICE)."
   type        = string
   default     = ""
+}
+
+# Explicit opt-in to create a DIMENSIONAL SERVICE anomaly monitor if none exists.
+# This should remain false in CI; enable only when you intend to create a new monitor.
+variable "create_ce_anomaly_monitor" {
+  description = "Whether to create a new Cost Explorer DIMENSIONAL SERVICE anomaly monitor if ce_monitor_arn is empty."
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
Summary:
- Terraform: Only create Cost Explorer DIMENSIONAL SERVICE monitor when explicitly enabled (create_ce_anomaly_monitor=true). Otherwise reuse existing via ce_monitor_arn; create subscription only when ARN is present.
- Workflow: Use `aws ce get-anomaly-monitors` (region us-east-1), export TF_VAR_create_ce_anomaly_monitor=false, keep daily canary schedule.
- Dockerfiles (catalog/order/user): Switch health checks to /live to avoid DB pings by /health.

Outcome:
- Eliminates CE monitor limit failures in CI (no default creation).
- Stops periodic DB touches from health checks; can monitor Neon for reduction.

After merge: please re-run “Terraform Apply (App Runner)”.