### PR TITLE
Option A: disable/remove CloudWatch Synthetics canary for auth /live

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -59,6 +59,8 @@ jobs:
           # Force a safe daily schedule regardless of org/repo secrets to avoid accidental cost spikes
           echo "TF_VAR_canary_schedule_expression=cron(0 0 * * ? *)" >> $GITHUB_ENV
           echo "TF_VAR_create_ce_anomaly_monitor=false" >> $GITHUB_ENV
+          # Disable the canary by default to avoid cost/noise
+          echo "TF_VAR_enable_auth_ready_canary=false" >> $GITHUB_ENV
 
 
 

--- a/terraform/app_runner/canary.tf
+++ b/terraform/app_runner/canary.tf
@@ -13,23 +13,27 @@ data "aws_iam_role" "synthetics_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "synthetics_full_access" {
+  count     = var.enable_auth_ready_canary ? 1 : 0
   role       = data.aws_iam_role.synthetics_role.name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchSyntheticsFullAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  count     = var.enable_auth_ready_canary ? 1 : 0
   role       = data.aws_iam_role.synthetics_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 resource "aws_iam_role_policy_attachment" "s3_rw" {
+  count     = var.enable_auth_ready_canary ? 1 : 0
   role       = data.aws_iam_role.synthetics_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
 resource "aws_iam_role_policy" "synthetics_putmetrics" {
-  name = "${var.project}-synthetics-putmetrics"
-  role = data.aws_iam_role.synthetics_role.name
+  count = var.enable_auth_ready_canary ? 1 : 0
+  name  = "${var.project}-synthetics-putmetrics"
+  role  = data.aws_iam_role.synthetics_role.name
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [{
@@ -40,8 +44,9 @@ resource "aws_iam_role_policy" "synthetics_putmetrics" {
   })
 }
 
-# Canary that polls auth-service /ready every 2 minutes
+# Canary that polls auth-service /ready (optional)
 resource "aws_synthetics_canary" "auth_ready" {
+  count                = var.enable_auth_ready_canary ? 1 : 0
   name                 = "${var.project}-auth-ready"
   artifact_s3_location = "s3://${data.aws_s3_bucket.synthetics_artifacts.bucket}"
   execution_role_arn   = data.aws_iam_role.synthetics_role.arn
@@ -75,4 +80,3 @@ variable "canary_schedule_expression" {
   # Use a cron expression to run daily at 00:00 UTC; aligns with cost optimization
   default     = "cron(0 0 * * ? *)"
 }
-

--- a/terraform/app_runner/variables.tf
+++ b/terraform/app_runner/variables.tf
@@ -108,3 +108,10 @@ variable "create_ce_anomaly_monitor" {
   type        = bool
   default     = false
 }
+
+# Enable/disable the auth /live CloudWatch Synthetics canary
+variable "enable_auth_ready_canary" {
+  description = "Whether to create and run the CloudWatch Synthetics canary for auth /live."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- Add enable_auth_ready_canary (default false) and guard all Canary resources with count
- Ensure CI exports TF_VAR_enable_auth_ready_canary=false
- This will destroy the existing canary on apply and stop runs/errors/costs

If we ever want it back, set enable_auth_ready_canary=true with a daily cron.