### PR TITLE
auth-service: stop idle DB wake-ups by removing periodic cleanup; switch to opportunistic cleanup

### DIFF
--- a/backend/auth-service/cmd/server/main.go
+++ b/backend/auth-service/cmd/server/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/expomadeinworld/madeinworld/auth-service/internal/api"
 	"github.com/expomadeinworld/madeinworld/auth-service/internal/db"
 	"github.com/expomadeinworld/madeinworld/auth-service/internal/logging"
-	"github.com/expomadeinworld/madeinworld/auth-service/internal/services"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 )
@@ -45,13 +44,9 @@ func main() {
 	// Initialize handlers (DB may be nil; /ready will report accordingly)
 	handler := api.NewHandler(database)
 
-	// Initialize cleanup service (runs every 30 minutes) only if DB is available
-	if database != nil {
-		cleanupService := services.NewCleanupService(database, 30)
-		cleanupService.Start()
-		defer cleanupService.Stop()
-	} else {
-		log.Println("[WARN] Skipping cleanup service start; database unavailable at startup")
+	// Periodic cleanup disabled: we now perform opportunistic cleanup during auth requests
+	if database == nil {
+		log.Println("[WARN] Database unavailable at startup; readiness will report accordingly")
 	}
 
 	// Set up Gin router

--- a/backend/auth-service/internal/api/admin_handlers.go
+++ b/backend/auth-service/internal/api/admin_handlers.go
@@ -98,6 +98,11 @@ func (h *Handler) AdminSendVerification(c *gin.Context) {
 	expirationMinutes := getEnvInt("CODE_EXPIRATION_MINUTES", 10)
 	expiresAt := time.Now().Add(time.Duration(expirationMinutes) * time.Minute)
 
+	// Opportunistic cleanup before creating a new code (best effort)
+	if cleanErr := h.DB.CleanupExpiredCodes(ctx); cleanErr != nil {
+		fmt.Printf("[ADMIN_AUTH] Cleanup before code creation failed: %v\n", cleanErr)
+	}
+
 	// Store verification code in database
 	verificationCode, err := h.DB.CreateVerificationCode(ctx, req.Email, string(codeHash), clientIP, expiresAt)
 	if err != nil {
@@ -137,6 +142,11 @@ func (h *Handler) AdminSendVerification(c *gin.Context) {
 	// Security logging - success
 	fmt.Printf("[ADMIN_AUTH] Verification code sent successfully to %s from IP: %s\n",
 		req.Email, clientIP)
+
+	// Opportunistic cleanup after successful send (best effort)
+	if cleanErr := h.DB.CleanupExpiredCodes(ctx); cleanErr != nil {
+		fmt.Printf("[ADMIN_AUTH] Cleanup after code send failed: %v\n", cleanErr)
+	}
 
 	// Return success response
 	c.JSON(http.StatusOK, models.SendVerificationResponse{

--- a/backend/auth-service/internal/api/handlers.go
+++ b/backend/auth-service/internal/api/handlers.go
@@ -459,6 +459,11 @@ func (h *Handler) UserSendVerification(c *gin.Context) {
 	expirationMinutes := getEnvInt("CODE_EXPIRATION_MINUTES", 10)
 	expiresAt := time.Now().Add(time.Duration(expirationMinutes) * time.Minute)
 
+	// Opportunistic cleanup before creating a new code (best effort)
+	if cleanErr := h.DB.CleanupExpiredUserCodes(ctx); cleanErr != nil {
+		fmt.Printf("[USER_AUTH] Cleanup before user code creation failed: %v\n", cleanErr)
+	}
+
 	// Store verification code in database
 	verificationCode, err := h.DB.CreateUserVerificationCode(ctx, req.Email, string(codeHash), clientIP, expiresAt)
 	if err != nil {
@@ -498,6 +503,11 @@ func (h *Handler) UserSendVerification(c *gin.Context) {
 	// Security logging - success
 	fmt.Printf("[USER_AUTH] Verification code sent successfully to %s from IP: %s\n",
 		req.Email, clientIP)
+
+	// Opportunistic cleanup after successful send (best effort)
+	if cleanErr := h.DB.CleanupExpiredUserCodes(ctx); cleanErr != nil {
+		fmt.Printf("[USER_AUTH] Cleanup after user code send failed: %v\n", cleanErr)
+	}
 
 	// Return success response
 	c.JSON(http.StatusOK, models.SendUserVerificationResponse{


### PR DESCRIPTION
Summary
- Remove 30-minute background CleanupService ticker from auth-service startup
- Perform opportunistic cleanup around auth requests (admin + user) instead
- This prevents Neon from being pinged when the system is idle, while still keeping verification tables tidy during actual usage

Changes
- backend/auth-service/cmd/server/main.go: remove ticker init
- backend/auth-service/internal/api/admin_handlers.go: call CleanupExpiredCodes() before/after sending admin code (best-effort)
- backend/auth-service/internal/api/handlers.go: call CleanupExpiredUserCodes() before/after sending user code (best-effort)

Build
- go build ./backend/auth-service succeeded locally

Expected outcome
- After deploy, the exact 30-minute CPU/RAM spikes should stop when there’s no traffic.

Follow-up
- If any periodic spikes remain, we’ll check for leftover CloudWatch Synthetics canaries calling /ready and either delete or switch them to /live on a daily schedule.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author