### PR TITLE
Hotfix: cast store_id to int in /products to avoid type errors

### DIFF
--- a/admin-panel/src/components/ImageCarousel.js
+++ b/admin-panel/src/components/ImageCarousel.js
@@ -6,7 +6,7 @@ import {
   IconButton,
   Typography,
   Button,
-  Grid,
+
   Chip,
   Dialog,
   DialogTitle,
@@ -20,7 +20,7 @@ import {
   ArrowDownward as ArrowDownIcon,
   Star as StarIcon,
   StarBorder as StarBorderIcon,
-  Add as AddIcon,
+
   CloudUpload as CloudUploadIcon,
 } from '@mui/icons-material';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';

--- a/admin-panel/src/components/Layout.js
+++ b/admin-panel/src/components/Layout.js
@@ -12,8 +12,8 @@ import {
   Toolbar,
   Typography,
   useTheme,
-  useMediaQuery,
-  Button,
+
+
   Avatar,
   Menu,
   MenuItem,

--- a/admin-panel/src/components/OrderDetailsModal.js
+++ b/admin-panel/src/components/OrderDetailsModal.js
@@ -16,7 +16,7 @@ import {
   TableHead,
   TableRow,
   Paper,
-  Divider,
+
   TextField,
   MenuItem,
   IconButton,

--- a/admin-panel/src/components/ProductForm.js
+++ b/admin-panel/src/components/ProductForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -17,16 +17,10 @@ import {
   Stepper,
   Step,
   StepLabel,
-  Card,
-  CardContent,
-  Avatar,
   FormControlLabel,
   Switch,
 } from '@mui/material';
-import {
-  CloudUpload as UploadIcon,
-  CheckCircle as SuccessIcon,
-} from '@mui/icons-material';
+
 import { productService, storeService, categoryService } from '../services/api';
 import { useToast } from '../contexts/ToastContext';
 import ImageCarousel from './ImageCarousel';
@@ -39,7 +33,7 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
-  
+
   // Form data
   const [formData, setFormData] = useState({
     // Step 1 - Basic Product Details
@@ -75,19 +69,15 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
   const [loadingCategories, setLoadingCategories] = useState(false);
   const [loadingSubcategories, setLoadingSubcategories] = useState(false);
 
-  // Mini-app type options
-  const miniAppTypes = [
+  // Mini-app type options (memoized to stabilize dependencies)
+  const miniAppTypes = useMemo(() => ([
     { value: '零售门店', label: '零售门店', requiresStore: false },
     { value: '无人商店', label: '无人商店', requiresStore: true },
     { value: '展销展消', label: '展销展消', requiresStore: true },
     { value: '团购团批', label: '团购团批', requiresStore: false },
-  ];
+  ]), []);
 
-  // Load initial data when component mounts
-  useEffect(() => {
-    // Load categories for default mini-app type
-    loadCategories(formData.mini_app_type);
-  }, []);
+
 
   // Helper function to convert backend mini-app type to frontend display value
   const convertBackendMiniAppType = (backendType) => {
@@ -100,70 +90,7 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
     return backendToFrontendMap[backendType] || '零售门店';
   };
 
-  // Initialize form data when editing an existing product
-  useEffect(() => {
-    if (product && open) {
-      // Convert backend mini-app type to frontend value
-      const frontendMiniAppType = convertBackendMiniAppType(product.mini_app_type);
 
-      setFormData({
-        title: product.title || '',
-        sku: product.sku || '',
-        description_long: product.description_long || '',
-        main_price: product.main_price || '',
-        strikethrough_price: product.strikethrough_price || '',
-        cost_price: product.cost_price || '',
-        stock_left: product.stock_left || 0,
-        minimum_order_quantity: product.minimum_order_quantity || 1,
-        mini_app_type: frontendMiniAppType,
-        store_id: product.store_id || null,
-        category_ids: product.category_ids || [],
-        subcategory_ids: product.subcategory_ids || [],
-        is_featured: product.is_featured || false,
-        is_mini_app_recommendation: product.is_mini_app_recommendation || false,
-        is_active: product.is_active !== undefined ? product.is_active : true,
-      });
-      setProductId(product.id);
-
-      // Load existing product images
-      loadProductImages(product.id);
-
-      // Load categories for the product's mini-app type
-      loadCategories(frontendMiniAppType);
-
-      // Load subcategories if the product has existing categories
-      if (product.category_ids && product.category_ids.length > 0) {
-        loadSubcategories(product.category_ids[0]);
-      }
-
-      // Load stores if required
-      if (['无人商店', '展销展消'].includes(frontendMiniAppType)) {
-        loadStores(frontendMiniAppType);
-      }
-    } else if (!product && open) {
-      // Reset form for new product creation
-      setFormData({
-        title: '',
-        sku: '',
-        description_long: '',
-        main_price: '',
-        strikethrough_price: '',
-        cost_price: '',
-        stock_left: 0,
-        minimum_order_quantity: 1,
-        mini_app_type: '零售门店',
-        store_id: null,
-        category_ids: [],
-        subcategory_ids: [],
-        is_featured: false,
-        is_mini_app_recommendation: false,
-        is_active: true,
-      });
-      setProductId(null);
-      setProductImages([]);
-      setActiveStep(0);
-    }
-  }, [product, open]);
 
   const handleInputChange = (field) => (event) => {
     const value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
@@ -195,7 +122,7 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
   };
 
   // Load stores based on mini-app type
-  const loadStores = async (miniAppType) => {
+  const loadStores = useCallback(async (miniAppType) => {
     if (!miniAppTypes.find(type => type.value === miniAppType)?.requiresStore) {
       setStores([]);
       return;
@@ -214,10 +141,10 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
     } finally {
       setLoadingStores(false);
     }
-  };
+  }, [miniAppTypes, showError]);
 
   // Load categories based on mini-app type and store
-  const loadCategories = async (miniAppType, storeId = null) => {
+  const loadCategories = useCallback(async (miniAppType, storeId = null) => {
     try {
       setLoadingCategories(true);
       const miniAppTypeMap = {
@@ -239,10 +166,10 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
     } finally {
       setLoadingCategories(false);
     }
-  };
+  }, [showError]);
 
   // Load subcategories for a specific category
-  const loadSubcategories = async (categoryId) => {
+  const loadSubcategories = useCallback(async (categoryId) => {
     try {
       setLoadingSubcategories(true);
       const subcategoriesData = await categoryService.getSubcategories(categoryId);
@@ -254,7 +181,7 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
     } finally {
       setLoadingSubcategories(false);
     }
-  };
+  }, [showError]);
 
   // Load existing product images when editing
   const loadProductImages = async (productId) => {
@@ -314,12 +241,72 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
     setSubcategories([]);
   };
 
+  // Load categories when mini-app type changes or on mount
+  useEffect(() => {
+    loadCategories(formData.mini_app_type);
+  }, [formData.mini_app_type, loadCategories]);
+
+  // Initialize form data when editing an existing product
+  useEffect(() => {
+    if (product && open) {
+      const frontendMiniAppType = convertBackendMiniAppType(product.mini_app_type);
+      setFormData({
+        title: product.title || '',
+        sku: product.sku || '',
+        description_long: product.description_long || '',
+        main_price: product.main_price || '',
+        strikethrough_price: product.strikethrough_price || '',
+        cost_price: product.cost_price || '',
+        stock_left: product.stock_left || 0,
+        minimum_order_quantity: product.minimum_order_quantity || 1,
+        mini_app_type: frontendMiniAppType,
+        store_id: product.store_id || null,
+        category_ids: product.category_ids || [],
+        subcategory_ids: product.subcategory_ids || [],
+        is_featured: product.is_featured || false,
+        is_mini_app_recommendation: product.is_mini_app_recommendation || false,
+        is_active: product.is_active !== undefined ? product.is_active : true,
+      });
+      setProductId(product.id);
+      loadProductImages(product.id);
+      loadCategories(frontendMiniAppType);
+      if (product.category_ids && product.category_ids.length > 0) {
+        loadSubcategories(product.category_ids[0]);
+      }
+      if (['无人商店', '展销展消'].includes(frontendMiniAppType)) {
+        loadStores(frontendMiniAppType);
+      }
+    } else if (!product && open) {
+      setFormData({
+        title: '',
+        sku: '',
+        description_long: '',
+        main_price: '',
+        strikethrough_price: '',
+        cost_price: '',
+        stock_left: 0,
+        minimum_order_quantity: 1,
+        mini_app_type: '零售门店',
+        store_id: null,
+        category_ids: [],
+        subcategory_ids: [],
+        is_featured: false,
+        is_mini_app_recommendation: false,
+        is_active: true,
+      });
+      setProductId(null);
+      setProductImages([]);
+      setActiveStep(0);
+    }
+  }, [product, open, loadCategories, loadStores, loadSubcategories]);
+
   // Handle multiple image upload
   const handleMultipleImageUpload = async (files) => {
     if (!productId) {
       showError('Please create the product first');
       return;
     }
+
 
     try {
       setUploadingImages(true);
@@ -338,7 +325,7 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
       });
 
       if (!response.ok) {
-        const errorText = await response.text();
+        await response.text(); // consume body for better error context (optional)
         throw new Error(`Failed to upload images: ${response.status} ${response.statusText}`);
       }
 
@@ -620,7 +607,7 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
         <Typography variant="h5" sx={{ fontWeight: 600 }}>
           {product ? 'Edit Product' : 'Add New Product'}
         </Typography>
-        
+
         <Stepper activeStep={activeStep} sx={{ mt: 2 }}>
           {steps.map((label) => (
             <Step key={label}>
@@ -636,7 +623,7 @@ const ProductForm = ({ open, onClose, onProductCreated, product = null, onProduc
             {error}
           </Alert>
         )}
-        
+
         {success && (
           <Alert severity="success" sx={{ mb: 2 }}>
             {success}

--- a/admin-panel/src/components/ProductStatusToggle.js
+++ b/admin-panel/src/components/ProductStatusToggle.js
@@ -7,7 +7,7 @@ import {
   Alert,
   Snackbar,
 } from '@mui/material';
-import { productService } from '../services/api';
+
 
 const ProductStatusToggle = ({ product, onStatusChanged }) => {
   const [loading, setLoading] = useState(false);

--- a/admin-panel/src/contexts/AuthContext.js
+++ b/admin-panel/src/contexts/AuthContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 
 const AuthContext = createContext();
@@ -103,7 +103,7 @@ export const AuthProvider = ({ children }) => {
     delete axios.defaults.headers.common['Authorization'];
   };
 
-  const refreshToken = async () => {
+  const refreshToken = useCallback(async () => {
     try {
       const API_BASE = process.env.REACT_APP_API_BASE_URL || 'https://device-api.expomadeinworld.com';
       const response = await axios.post(`${API_BASE}/api/auth/refresh`, {}, {
@@ -131,7 +131,7 @@ export const AuthProvider = ({ children }) => {
       logout();
       return false;
     }
-  };
+  }, [token]);
 
   // Auto-refresh token before expiration
   useEffect(() => {
@@ -162,7 +162,7 @@ export const AuthProvider = ({ children }) => {
     } catch (error) {
       console.error('Error setting up token refresh:', error);
     }
-  }, [token, isAuthenticated]);
+  }, [token, isAuthenticated, refreshToken]);
 
   const value = {
     isAuthenticated,

--- a/admin-panel/src/pages/CartListPage.js
+++ b/admin-panel/src/pages/CartListPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Card,
@@ -32,7 +32,7 @@ import {
   Delete as DeleteIcon,
   FilterList as FilterIcon,
   Search as SearchIcon,
-  ShoppingBasket as CartIcon,
+
 } from '@mui/icons-material';
 import { cartService } from '../services/api';
 import { useToast } from '../contexts/ToastContext';
@@ -49,7 +49,7 @@ const CartListPage = () => {
   const [selectedCart, setSelectedCart] = useState(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [cartToDelete, setCartToDelete] = useState(null);
-  
+
   // Filters
   const [filters, setFilters] = useState({
     search: '',
@@ -78,11 +78,9 @@ const CartListPage = () => {
     GroupBuying: '#076200',
   };
 
-  useEffect(() => {
-    fetchCarts();
-  }, [page, rowsPerPage, filters]);
 
-  const fetchCarts = async () => {
+
+  const fetchCarts = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -110,9 +108,15 @@ const CartListPage = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [page, rowsPerPage, filters, showToast]);
+
+  useEffect(() => {
+    fetchCarts();
+  }, [fetchCarts]);
 
   const handleChangePage = (event, newPage) => {
+
+
     setPage(newPage);
   };
 

--- a/admin-panel/src/pages/CategoryListPage.js
+++ b/admin-panel/src/pages/CategoryListPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Box,
   Typography,
@@ -98,7 +98,7 @@ const CategoryListPage = () => {
     return storeTypeOptions.find(opt => opt.value === type) || { color: '#666', miniApp: 'Unknown' };
   };
 
-  const miniAppTabs = [
+  const miniAppTabs = useMemo(() => [
     {
       value: 'RetailStore',
       label: '零售门店',
@@ -131,19 +131,13 @@ const CategoryListPage = () => {
       requiresStore: false,
       description: 'Direct category management without store location'
     },
-  ];
+] , []);
 
-  useEffect(() => {
-    fetchCategories();
-    fetchStores();
-  }, []);
 
-  useEffect(() => {
-    fetchCategories();
-    fetchStores(); // Also fetch stores when tab changes
-  }, [currentTab, selectedStore]);
 
-  const fetchCategories = async () => {
+
+
+  const fetchCategories = useCallback(async () => {
     try {
       setLoading(true);
       const currentMiniApp = miniAppTabs[currentTab];
@@ -171,9 +165,9 @@ const CategoryListPage = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [currentTab, selectedStore, miniAppTabs, showToast]);
 
-  const fetchStores = async () => {
+  const fetchStores = useCallback(async () => {
     try {
       const currentMiniApp = miniAppTabs[currentTab];
       if (!currentMiniApp.requiresStore) {
@@ -201,13 +195,25 @@ const CategoryListPage = () => {
       showToast('Error fetching stores', 'error');
       setStores([]); // Reset to empty array on exception
     }
-  };
+  }, [currentTab, selectedStore, miniAppTabs, showToast]);
+
+  useEffect(() => {
+    fetchCategories();
+    fetchStores();
+  }, [fetchCategories, fetchStores]);
+
+  useEffect(() => {
+    fetchCategories();
+    fetchStores(); // Also fetch stores when tab changes
+  }, [currentTab, selectedStore, fetchCategories, fetchStores]);
 
   const handleCreateCategory = async () => {
     try {
       // Validate display order
       if (categoryForm.display_order < 1) {
         showToast('Display order must be at least 1', 'error');
+
+
         return;
       }
 

--- a/admin-panel/src/pages/OrderListPage.js
+++ b/admin-panel/src/pages/OrderListPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Card,
@@ -30,9 +30,9 @@ import {
 } from '@mui/material';
 import {
   Visibility as ViewIcon,
-  Edit as EditIcon,
+
   Delete as DeleteIcon,
-  FilterList as FilterIcon,
+
   Search as SearchIcon,
 } from '@mui/icons-material';
 import { orderService } from '../services/api';
@@ -52,7 +52,7 @@ const OrderListPage = () => {
   const [bulkUpdateModalOpen, setBulkUpdateModalOpen] = useState(false);
   const [bulkStatus, setBulkStatus] = useState('');
   const [bulkReason, setBulkReason] = useState('');
-  
+
   // Filters
   const [filters, setFilters] = useState({
     search: '',
@@ -82,11 +82,9 @@ const OrderListPage = () => {
     GroupBuying: '团购团批',
   };
 
-  useEffect(() => {
-    fetchOrders();
-  }, [page, rowsPerPage, filters]);
 
-  const fetchOrders = async () => {
+
+  const fetchOrders = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -114,9 +112,15 @@ const OrderListPage = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [page, rowsPerPage, filters, showToast]);
+
+  useEffect(() => {
+    fetchOrders();
+  }, [fetchOrders]);
 
   const handleChangePage = (event, newPage) => {
+
+
     setPage(newPage);
   };
 

--- a/admin-panel/src/pages/StoreListPage.js
+++ b/admin-panel/src/pages/StoreListPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Typography,
@@ -19,12 +19,12 @@ import {
   MenuItem,
   Alert,
   Avatar,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemSecondaryAction,
-  ListItemAvatar,
-  Fab,
+
+
+
+
+
+
   Tooltip,
 } from '@mui/material';
 import {
@@ -51,7 +51,7 @@ const StoreListPage = () => {
   const [loading, setLoading] = useState(true);
   const [openDialog, setOpenDialog] = useState(false);
   const [editingStore, setEditingStore] = useState(null);
-  const [selectedImage, setSelectedImage] = useState(null);
+  const [, setSelectedImage] = useState(null);
   const { showToast } = useToast();
 
   const [storeForm, setStoreForm] = useState({
@@ -72,11 +72,9 @@ const StoreListPage = () => {
     { value: '展销商城', label: '展销商城', color: '#f38900', miniApp: '展销展消' },
   ];
 
-  useEffect(() => {
-    fetchStores();
-  }, []);
 
-  const fetchStores = async () => {
+
+  const fetchStores = useCallback(async () => {
     try {
       setLoading(true);
       const response = await fetch(`${API_BASE}/api/v1/stores`);
@@ -92,9 +90,15 @@ const StoreListPage = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [showToast]);
+
+  useEffect(() => {
+    fetchStores();
+  }, [fetchStores]);
 
   const handleCreateStore = async () => {
+
+
     try {
       const response = await fetch(`${API_BASE}/api/v1/stores`, {
         method: 'POST',

--- a/backend/catalog-service/internal/api/handlers.go
+++ b/backend/catalog-service/internal/api/handlers.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"database/sql"
+
 	"fmt"
 	"io"
 	"log"
@@ -310,11 +312,11 @@ func (h *Handler) GetProducts(c *gin.Context) {
             SELECT
                 p.product_id, p.product_uuid, p.sku, p.title, p.description_short, p.description_long,
                 p.manufacturer_id,
-                CASE
+                COALESCE(CASE
                     WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL
                     THEN s.type
                     ELSE p.store_type
-                END as store_type,
+                END, '') as store_type,
                 p.mini_app_type, p.store_id, p.main_price, p.strikethrough_price,
                 p.cost_price, p.stock_left, p.minimum_order_quantity, p.is_active, p.is_featured, p.is_mini_app_recommendation, p.created_at, p.updated_at
             FROM products p
@@ -327,11 +329,11 @@ func (h *Handler) GetProducts(c *gin.Context) {
             SELECT
                 p.product_id, p.product_uuid, p.sku, p.title, p.description_short, p.description_long,
                 p.manufacturer_id,
-                CASE
+                COALESCE(CASE
                     WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL
                     THEN s.type
                     ELSE p.store_type
-                END as store_type,
+                END, '') as store_type,
                 p.mini_app_type, p.store_id, p.main_price, p.strikethrough_price,
                 p.stock_left, p.minimum_order_quantity, p.is_active, p.is_featured, p.is_mini_app_recommendation, p.created_at, p.updated_at
             FROM products p
@@ -403,6 +405,7 @@ func (h *Handler) GetProducts(c *gin.Context) {
 	for rows.Next() {
 		var product models.Product
 		var err error
+		var storeType sql.NullString
 
 		if isAdminRequest {
 			err = rows.Scan(
@@ -413,7 +416,7 @@ func (h *Handler) GetProducts(c *gin.Context) {
 				&product.DescriptionShort,
 				&product.DescriptionLong,
 				&product.ManufacturerID,
-				&product.StoreType,
+				&storeType,
 				&product.MiniAppType,
 				&product.StoreID,
 				&product.MainPrice,
@@ -436,7 +439,7 @@ func (h *Handler) GetProducts(c *gin.Context) {
 				&product.DescriptionShort,
 				&product.DescriptionLong,
 				&product.ManufacturerID,
-				&product.StoreType,
+				&storeType,
 				&product.MiniAppType,
 				&product.StoreID,
 				&product.MainPrice,
@@ -455,6 +458,8 @@ func (h *Handler) GetProducts(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scan product"})
 			return
 		}
+		// Normalize nullable store_type from DB into string type
+		product.StoreType = models.StoreType(storeType.String)
 
 		// Get product images
 		images, err := h.getProductImages(ctx, product.ID)
@@ -630,6 +635,7 @@ func (h *Handler) GetProduct(c *gin.Context) {
 
 	var product models.Product
 	var err error
+	var storeType sql.NullString
 
 	if isAdminRequest {
 		err = h.db.Pool.QueryRow(ctx, query, queryParam).Scan(
@@ -640,7 +646,7 @@ func (h *Handler) GetProduct(c *gin.Context) {
 			&product.DescriptionShort,
 			&product.DescriptionLong,
 			&product.ManufacturerID,
-			&product.StoreType,
+			&storeType,
 			&product.MiniAppType,
 			&product.StoreID,
 			&product.MainPrice,
@@ -663,7 +669,7 @@ func (h *Handler) GetProduct(c *gin.Context) {
 			&product.DescriptionShort,
 			&product.DescriptionLong,
 			&product.ManufacturerID,
-			&product.StoreType,
+			&storeType,
 			&product.MiniAppType,
 			&product.StoreID,
 			&product.MainPrice,
@@ -683,6 +689,8 @@ func (h *Handler) GetProduct(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Product not found"})
 		return
 	}
+	// Normalize nullable store_type from DB into string type
+	product.StoreType = models.StoreType(storeType.String)
 
 	// Get product images
 	images, err := h.getProductImages(ctx, product.ID)

--- a/backend/catalog-service/internal/api/handlers.go
+++ b/backend/catalog-service/internal/api/handlers.go
@@ -373,8 +373,14 @@ func (h *Handler) GetProducts(c *gin.Context) {
 
 	// Add store ID filter
 	if storeID != "" {
+		sid, err := strconv.Atoi(storeID)
+		if err != nil {
+			log.Printf("Invalid store_id param '%s': %v", storeID, err)
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid store_id"})
+			return
+		}
 		query += fmt.Sprintf(" AND p.store_id = $%d", argIndex)
-		args = append(args, storeID)
+		args = append(args, sid)
 		argIndex++
 	}
 

--- a/backend/catalog-service/internal/api/handlers.go
+++ b/backend/catalog-service/internal/api/handlers.go
@@ -290,6 +290,7 @@ func (h *Handler) GetProducts(c *gin.Context) {
 
 	// Parse query parameters
 	storeType := c.Query("store_type")
+	miniAppType := c.Query("mini_app_type")
 	featured := c.Query("featured")
 	storeID := c.Query("store_id")
 
@@ -297,7 +298,7 @@ func (h *Handler) GetProducts(c *gin.Context) {
 	isAdminRequest := c.GetHeader("X-Admin-Request") == "true"
 
 	// Debug logging
-	log.Printf("🔍 DEBUG: GetProducts called with params - storeType: %s, featured: %s, storeID: %s, isAdmin: %t", storeType, featured, storeID, isAdminRequest)
+	log.Printf("🔍 DEBUG: GetProducts called with params - storeType: %s, miniAppType: %s, featured: %s, storeID: %s, isAdmin: %t", storeType, miniAppType, featured, storeID, isAdminRequest)
 
 	// Build the query - include cost_price only for admin requests
 	// For location-dependent mini-apps (UnmannedStore, ExhibitionSales), we need to JOIN with stores table
@@ -342,14 +343,30 @@ func (h *Handler) GetProducts(c *gin.Context) {
 	args := []interface{}{}
 	argIndex := 1
 
-	// Add store type filter
-	if storeType != "" {
-		// Use the same logic as the SELECT statement for store type filtering
-		query += fmt.Sprintf(" AND (CASE WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL THEN s.type ELSE p.store_type END) = $%d", argIndex)
-		// Convert English enum values to Chinese database values
-		dbStoreType := convertStoreTypeToDBValue(storeType)
-		args = append(args, dbStoreType)
+	// Add mini-app type filter first (authoritative)
+	if miniAppType != "" {
+		query += fmt.Sprintf(" AND p.mini_app_type = $%d", argIndex)
+		args = append(args, miniAppType)
 		argIndex++
+	}
+
+	// Add store type filter (only for location-based mini-apps)
+	if storeType != "" {
+		// If a non-location mini-app type sneaks in via store_type, coerce to mini_app_type filter
+		if storeType == "RetailStore" || storeType == "GroupBuying" {
+			if miniAppType == "" {
+				query += fmt.Sprintf(" AND p.mini_app_type = $%d", argIndex)
+				args = append(args, storeType)
+				argIndex++
+			}
+		} else {
+			// Use the same logic as the SELECT statement for store type filtering
+			query += fmt.Sprintf(" AND (CASE WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL THEN s.type ELSE p.store_type END) = $%d", argIndex)
+			// Convert English enum values to Chinese database values
+			dbStoreType := convertStoreTypeToDBValue(storeType)
+			args = append(args, dbStoreType)
+			argIndex++
+		}
 	}
 
 	// Add store ID filter

--- a/madeinworld_app/lib/data/services/api_service.dart
+++ b/madeinworld_app/lib/data/services/api_service.dart
@@ -26,6 +26,7 @@ class ApiService {
   /// [storeId] - Get stock for specific store (optional, for unmanned stores)
   Future<List<Product>> fetchProducts({
     StoreType? storeType,
+    MiniAppType? miniAppType,
     bool? featured,
     int? storeId,
   }) async {
@@ -35,6 +36,10 @@ class ApiService {
 
       if (storeType != null) {
         queryParams['store_type'] = storeType.apiValue;
+      }
+
+      if (miniAppType != null) {
+        queryParams['mini_app_type'] = miniAppType.apiValue;
       }
 
       if (featured != null) {

--- a/madeinworld_app/lib/presentation/screens/mini_apps/group_buying/group_buying_screen.dart
+++ b/madeinworld_app/lib/presentation/screens/mini_apps/group_buying/group_buying_screen.dart
@@ -216,7 +216,7 @@ class _ProductsTabState extends State<_ProductsTab> {
         includeSubcategories: true,
       );
       _productsFuture = _apiService.fetchProducts(
-        storeType: StoreType.groupBuying, // Filter by group buying store type
+        miniAppType: MiniAppType.groupBuying,
       );
     });
   }

--- a/madeinworld_app/lib/presentation/screens/mini_apps/retail_store/retail_store_screen.dart
+++ b/madeinworld_app/lib/presentation/screens/mini_apps/retail_store/retail_store_screen.dart
@@ -263,7 +263,7 @@ class _ProductsTabState extends State<_ProductsTab> {
       includeSubcategories: true,
     );
     _productsFuture = _apiService.fetchProducts(
-      storeType: StoreType.retailStore, // Filter by retail store type
+      miniAppType: MiniAppType.retailStore,
     );
   }
 
@@ -313,7 +313,9 @@ class _ProductsTabState extends State<_ProductsTab> {
                         miniAppType: MiniAppType.retailStore,
                         includeSubcategories: true,
                       );
-                      _productsFuture = _apiService.fetchProducts();
+                      _productsFuture = _apiService.fetchProducts(
+                            miniAppType: MiniAppType.retailStore,
+                          );
                     });
                   },
                   style: ElevatedButton.styleFrom(


### PR DESCRIPTION
Context
- After the DB cleanup (store_type NULL for Retail/GroupBuying), /products began failing in prod. We already merged PR #55 to handle NULL store_type scans.
- Additional hardening: ensure store_id filter is always passed as int to the DB to avoid integer=text mismatches that can surface on some queries.

Change
- In GetProducts: parse store_id with strconv.Atoi and pass an int argument; return 400 if invalid.
- No changes to business logic; joins/filters stay the same.

Build
- catalog-service builds cleanly locally.

Next
- Please deploy along with PR #55 so both fixes are live in prod.