### PR TITLE
Hotfix: null-safe string fields in catalog-service product selects

### DIFF
--- a/backend/catalog-service/internal/api/handlers.go
+++ b/backend/catalog-service/internal/api/handlers.go
@@ -310,7 +310,7 @@ func (h *Handler) GetProducts(c *gin.Context) {
 		// Admin requests show ALL products (active and inactive) for complete management
 		query = `
             SELECT
-                p.product_id, p.product_uuid, p.sku, p.title, p.description_short, p.description_long,
+                p.product_id, p.product_uuid, COALESCE(p.sku, '') as sku, p.title, COALESCE(p.description_short, '') as description_short, COALESCE(p.description_long, '') as description_long,
                 COALESCE(p.manufacturer_id, 0) as manufacturer_id,
                 COALESCE(CASE
                     WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL
@@ -327,7 +327,7 @@ func (h *Handler) GetProducts(c *gin.Context) {
 		// Public requests only show active products
 		query = `
             SELECT
-                p.product_id, p.product_uuid, p.sku, p.title, p.description_short, p.description_long,
+                p.product_id, p.product_uuid, COALESCE(p.sku, '') as sku, p.title, COALESCE(p.description_short, '') as description_short, COALESCE(p.description_long, '') as description_long,
                 COALESCE(p.manufacturer_id, 0) as manufacturer_id,
                 COALESCE(CASE
                     WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL
@@ -571,7 +571,7 @@ func (h *Handler) GetProduct(c *gin.Context) {
 		if isAdminRequest {
 			query = `
 	            SELECT
-	                p.product_id, p.product_uuid, p.sku, p.title, p.description_short, p.description_long,
+	                p.product_id, p.product_uuid, COALESCE(p.sku, '') as sku, p.title, COALESCE(p.description_short, '') as description_short, COALESCE(p.description_long, '') as description_long,
 	                COALESCE(p.manufacturer_id, 0) as manufacturer_id,
 	                CASE
 	                    WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL
@@ -587,7 +587,7 @@ func (h *Handler) GetProduct(c *gin.Context) {
 		} else {
 			query = `
 	            SELECT
-	                p.product_id, p.product_uuid, p.sku, p.title, p.description_short, p.description_long,
+	                p.product_id, p.product_uuid, COALESCE(p.sku, '') as sku, p.title, COALESCE(p.description_short, '') as description_short, COALESCE(p.description_long, '') as description_long,
 	                COALESCE(p.manufacturer_id, 0) as manufacturer_id,
 	                CASE
 	                    WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL
@@ -607,7 +607,7 @@ func (h *Handler) GetProduct(c *gin.Context) {
 		if isAdminRequest {
 			query = `
 	            SELECT
-	                p.product_id, p.product_uuid, p.sku, p.title, p.description_short, p.description_long,
+	                p.product_id, p.product_uuid, COALESCE(p.sku, '') as sku, p.title, COALESCE(p.description_short, '') as description_short, COALESCE(p.description_long, '') as description_long,
 	                COALESCE(p.manufacturer_id, 0) as manufacturer_id,
 	                CASE
 	                    WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL
@@ -623,7 +623,7 @@ func (h *Handler) GetProduct(c *gin.Context) {
 		} else {
 			query = `
 	            SELECT
-	                p.product_id, p.product_uuid, p.sku, p.title, p.description_short, p.description_long,
+	                p.product_id, p.product_uuid, COALESCE(p.sku, '') as sku, p.title, COALESCE(p.description_short, '') as description_short, COALESCE(p.description_long, '') as description_long,
 	                COALESCE(p.manufacturer_id, 0) as manufacturer_id,
 	                CASE
 	                    WHEN p.mini_app_type IN ('UnmannedStore', 'ExhibitionSales') AND s.type IS NOT NULL


### PR DESCRIPTION
Context
- Products endpoint continues to 500 due to NULL scanning into non-null Go string fields when some rows have NULLs in text columns.

Fix
- Wrap potentially nullable text columns in SELECTs with COALESCE to ensure non-null values during scan:
  - sku -> COALESCE(p.sku, '') as sku
  - description_short -> COALESCE(p.description_short, '') as description_short
  - description_long -> COALESCE(p.description_long, '') as description_long
- Applied to both GetProducts (admin/public) and GetProduct (admin/public) SELECTs.
- Builds clean locally.

Notes
- This follows the earlier hotfix that null-safed manufacturer_id and store_type.
- Should remove remaining causes of row scan failures.

After merge
- CI/CD will deploy via App Runner workflow.
- I will smoke test:
  - /api/v1/products?featured=true
  - /api/v1/products?mini_app_type=RetailStore
  - /api/v1/products?mini_app_type=GroupBuying
  - /api/v1/products?store_id=7
