### PR TITLE
auth-service: use App Runner instance role for SNS+SES; remove SES SMTP secrets; SESv2 API

### DIFF
--- a/backend/auth-service/cmd/server/main.go
+++ b/backend/auth-service/cmd/server/main.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/expomadeinworld/madeinworld/auth-service/internal/api"
 	"github.com/expomadeinworld/madeinworld/auth-service/internal/db"
 	"github.com/expomadeinworld/madeinworld/auth-service/internal/logging"
@@ -45,37 +44,34 @@ func main() {
 	}
 
 	// Initialize AWS configs separately for SES (email) and SNS (SMS)
-	// SES credentials
-	sesCreds := credentials.NewStaticCredentialsProvider(
-		os.Getenv("SES_AWS_ACCESS_KEY_ID"),
-		os.Getenv("SES_AWS_SECRET_ACCESS_KEY"),
-		"",
-	)
+	// SES config: use App Runner instance role (no SMTP secrets in prod)
 	sesRegion := os.Getenv("SES_AWS_REGION")
 	if sesRegion == "" {
-		sesRegion = "eu-central-1"
+		if os.Getenv("AWS_DEFAULT_REGION") != "" {
+			sesRegion = os.Getenv("AWS_DEFAULT_REGION")
+		} else {
+			sesRegion = "eu-central-1"
+		}
 	}
 	sesCfg, sesErr := config.LoadDefaultConfig(context.Background(),
 		config.WithRegion(sesRegion),
-		config.WithCredentialsProvider(sesCreds),
 	)
 	if sesErr != nil {
 		log.Printf("[WARN] SES AWS config load failed: %v", sesErr)
 	}
 
-	// SNS credentials
-	snsCreds := credentials.NewStaticCredentialsProvider(
-		os.Getenv("SNS_AWS_ACCESS_KEY_ID"),
-		os.Getenv("SNS_AWS_SECRET_ACCESS_KEY"),
-		"",
-	)
+	// SNS config: use App Runner instance role (no static keys in prod)
 	snsRegion := os.Getenv("SNS_AWS_REGION")
 	if snsRegion == "" {
-		snsRegion = "eu-central-1"
+		// fall back to AWS_DEFAULT_REGION if set, otherwise eu-central-1
+		if os.Getenv("AWS_DEFAULT_REGION") != "" {
+			snsRegion = os.Getenv("AWS_DEFAULT_REGION")
+		} else {
+			snsRegion = "eu-central-1"
+		}
 	}
 	snsCfg, snsErr := config.LoadDefaultConfig(context.Background(),
 		config.WithRegion(snsRegion),
-		config.WithCredentialsProvider(snsCreds),
 	)
 	if snsErr != nil {
 		log.Printf("[WARN] SNS AWS config load failed: %v", snsErr)

--- a/backend/auth-service/internal/services/email_service.go
+++ b/backend/auth-service/internal/services/email_service.go
@@ -1,42 +1,41 @@
 package services
 
 import (
+	"context"
 	"crypto/rand"
-	"crypto/tls"
 	"fmt"
 	"math/big"
-	"net/smtp"
 	"os"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	sesv2 "github.com/aws/aws-sdk-go-v2/service/sesv2"
+	sestypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/expomadeinworld/madeinworld/auth-service/internal/models"
 )
 
-// EmailService handles email sending via AWS SES SMTP
+// EmailService handles email sending via AWS SES (SESv2 API)
 type EmailService struct {
-	smtpHost     string
-	smtpPort     string
-	smtpUsername string
-	smtpPassword string
-	fromEmail    string
+	sesClient *sesv2.Client
+	fromEmail string
 }
 
-// NewEmailService creates a new email service instance with service-specific config
+// NewEmailService creates a new email service instance using AWS SDK (role-based)
 func NewEmailService(cfg aws.Config) *EmailService {
 	region := cfg.Region
 	if region == "" {
 		region = os.Getenv("SES_AWS_REGION")
 		if region == "" {
-			region = "eu-central-1"
+			if os.Getenv("AWS_DEFAULT_REGION") != "" {
+				region = os.Getenv("AWS_DEFAULT_REGION")
+			} else {
+				region = "eu-central-1"
+			}
 		}
 	}
+	cfg.Region = region
 	return &EmailService{
-		smtpHost:     fmt.Sprintf("email-smtp.%s.amazonaws.com", region),
-		smtpPort:     "587",
-		smtpUsername: os.Getenv("SES_AWS_ACCESS_KEY_ID"),
-		smtpPassword: os.Getenv("SES_AWS_SECRET_ACCESS_KEY"),
-		fromEmail:    os.Getenv("SES_FROM_EMAIL"),
+		sesClient: sesv2.NewFromConfig(cfg),
+		fromEmail: os.Getenv("SES_FROM_EMAIL"),
 	}
 }
 
@@ -67,38 +66,23 @@ func generateRandomID() string {
 	return string(result)
 }
 
-// sendEmail sends an email via AWS SES SMTP with enhanced anti-spam headers
+// sendEmail sends an email via AWS SESv2 using the instance role
 func (e *EmailService) sendEmail(toEmail, subject, htmlBody string) error {
-	// Set up authentication
-	auth := smtp.PlainAuth("", e.smtpUsername, e.smtpPassword, e.smtpHost)
-
-	// Use professional domain for From address, Gmail for Reply-To
-	replyToEmail := "expotobsrl@gmail.com"
-
-	// Create enhanced email message with anti-spam headers
-	message := fmt.Sprintf(`From: Made in World Admin <%s>
-To: %s
-Reply-To: %s
-Subject: %s
-Date: %s
-Message-ID: <%d.%s@expomadeinworld.com>
-MIME-Version: 1.0
-Content-Type: text/html; charset=UTF-8
-X-Mailer: Made in World Admin Panel v2.0
-X-Priority: 3
-X-MSMail-Priority: Normal
-List-Unsubscribe: <mailto:unsubscribe@expomadeinworld.com>
-
-%s`, e.fromEmail, toEmail, replyToEmail, subject,
-		time.Now().Format(time.RFC1123Z),
-		time.Now().Unix(), generateRandomID(), htmlBody)
-
-	// Send the email
-	err := smtp.SendMail(e.smtpHost+":"+e.smtpPort, auth, e.fromEmail, []string{toEmail}, []byte(message))
-	if err != nil {
+	replyTo := "expotobsrl@gmail.com"
+	input := &sesv2.SendEmailInput{
+		FromEmailAddress: aws.String(e.fromEmail),
+		Destination:      &sestypes.Destination{ToAddresses: []string{toEmail}},
+		ReplyToAddresses: []string{replyTo},
+		Content: &sestypes.EmailContent{
+			Simple: &sestypes.Message{
+				Subject: &sestypes.Content{Data: aws.String(subject)},
+				Body:    &sestypes.Body{Html: &sestypes.Content{Data: aws.String(htmlBody)}},
+			},
+		},
+	}
+	if _, err := e.sesClient.SendEmail(context.Background(), input); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
-
 	return nil
 }
 
@@ -417,35 +401,4 @@ func (e *EmailService) generateUserEmailHTML(data models.EmailVerificationData) 
 		data.UserAgent,
 		data.Email,
 	)
-}
-
-// TestConnection tests the SMTP connection
-func (e *EmailService) TestConnection() error {
-	// Test TLS connection
-	conn, err := tls.Dial("tcp", e.smtpHost+":465", &tls.Config{
-		ServerName: e.smtpHost,
-	})
-	if err == nil {
-		conn.Close()
-	}
-
-	// Test SMTP auth
-	auth := smtp.PlainAuth("", e.smtpUsername, e.smtpPassword, e.smtpHost)
-
-	// Create a simple test message
-	testMessage := fmt.Sprintf(`From: %s
-To: %s
-Subject: AWS SES Connection Test
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-
-This is a connection test for AWS SES SMTP.`, e.fromEmail, e.fromEmail)
-
-	// Try to send test email to self
-	err = smtp.SendMail(e.smtpHost+":"+e.smtpPort, auth, e.fromEmail, []string{e.fromEmail}, []byte(testMessage))
-	if err != nil {
-		return fmt.Errorf("SMTP connection test failed: %w", err)
-	}
-
-	return nil
 }

--- a/terraform/app_runner/apprunner.tf
+++ b/terraform/app_runner/apprunner.tf
@@ -88,12 +88,7 @@ resource "aws_apprunner_service" "main_services" {
         runtime_environment_secrets = merge(
           {},
           length(trimspace(var.secret_arn_db_password)) > 0 ? { DB_PASSWORD = var.secret_arn_db_password } : {},
-          length(trimspace(var.secret_arn_jwt_secret)) > 0 ? { JWT_SECRET = var.secret_arn_jwt_secret } : {},
-          # Only inject SES SMTP creds into auth-service; other services use instance role for AWS
-          (each.key == "auth-service" && length(trimspace(var.secret_arn_ses_user)) > 0 && length(trimspace(var.secret_arn_ses_pass)) > 0) ? {
-            AWS_ACCESS_KEY_ID     = var.secret_arn_ses_user
-            AWS_SECRET_ACCESS_KEY = var.secret_arn_ses_pass
-          } : {}
+          length(trimspace(var.secret_arn_jwt_secret)) > 0 ? { JWT_SECRET = var.secret_arn_jwt_secret } : {}
         )
       }
     }
@@ -101,7 +96,7 @@ resource "aws_apprunner_service" "main_services" {
   }
 
   instance_configuration {
-    instance_role_arn = aws_iam_role.apprunner_instance_role.arn
+    instance_role_arn = each.key == "auth-service" ? aws_iam_role.apprunner_instance_role_auth.arn : aws_iam_role.apprunner_instance_role.arn
     cpu               = "256"   # 0.25 vCPU
     memory            = "512"   # 0.5 GB
   }

--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -40,6 +40,82 @@ resource "aws_iam_role" "apprunner_instance_role" {
   })
 }
 
+# Dedicated instance role for auth-service (to use SNS publish)
+resource "aws_iam_role" "apprunner_instance_role_auth" {
+  name = "${var.project}-apprunner-instance-role-auth"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = { Service = "tasks.apprunner.amazonaws.com" },
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# Reuse existing secrets policy for auth role
+resource "aws_iam_role_policy_attachment" "apprunner_auth_secrets_access" {
+  role       = aws_iam_role.apprunner_instance_role_auth.name
+  policy_arn = aws_iam_policy.apprunner_secrets_policy.arn
+}
+
+# Reuse S3 put policy for auth role (compatibility)
+resource "aws_iam_role_policy_attachment" "apprunner_auth_s3_put_attach" {
+  role       = aws_iam_role.apprunner_instance_role_auth.name
+  policy_arn = aws_iam_policy.apprunner_s3_put_policy.arn
+}
+
+# SNS publish policy for auth-service
+data "aws_iam_policy_document" "apprunner_auth_sns_doc" {
+  statement {
+    effect  = "Allow"
+    actions = [
+      "sns:Publish",
+      "sns:GetSMSAttributes"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "apprunner_auth_sns_policy" {
+  name        = "${var.project}-apprunner-auth-sns"
+  description = "Allow auth-service to publish SMS via SNS"
+  policy      = data.aws_iam_policy_document.apprunner_auth_sns_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "apprunner_auth_sns_attach" {
+  role       = aws_iam_role.apprunner_instance_role_auth.name
+  policy_arn = aws_iam_policy.apprunner_auth_sns_policy.arn
+}
+
+# SES send email policy for auth-service
+data "aws_iam_policy_document" "apprunner_auth_ses_doc" {
+  statement {
+    effect  = "Allow"
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "apprunner_auth_ses_policy" {
+  name        = "${var.project}-apprunner-auth-ses"
+  description = "Allow auth-service to send email via SES"
+  policy      = data.aws_iam_policy_document.apprunner_auth_ses_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "apprunner_auth_ses_attach" {
+  role       = aws_iam_role.apprunner_instance_role_auth.name
+  policy_arn = aws_iam_policy.apprunner_auth_ses_policy.arn
+}
+
+
+
 # Construct policy document granting read access to specified secret ARNs
 data "aws_iam_policy_document" "apprunner_secrets_doc" {
   dynamic "statement" {
@@ -101,6 +177,7 @@ data "aws_iam_policy_document" "github_actions_passrole_doc" {
     resources = [
       aws_iam_role.apprunner_ecr_access_role.arn,
       aws_iam_role.apprunner_instance_role.arn,
+      aws_iam_role.apprunner_instance_role_auth.arn,
     ]
   }
 }


### PR DESCRIPTION
Summary
- auth-service now uses App Runner instance role for both SNS (SMS OTP) and SES (email) — no static keys in prod
- SES SMTP secret injection removed from App Runner config
- Added IAM policy for SES send (ses:SendEmail, ses:SendRawEmail) to dedicated auth-service instance role
- Switched email sending to SESv2 API client (role-based)
- Left SNS SMS implementation as direct phone publish with Transactional type using role

Files
- backend/auth-service/internal/services/email_service.go
- backend/auth-service/cmd/server/main.go
- terraform/app_runner/iam.tf
- terraform/app_runner/apprunner.tf
- go.mod/go.sum updated for sesv2

Rollout
1) Terraform Apply: updates IAM + App Runner service wiring
2) Deploy App Runner image: updates auth-service

Notes
- Region falls back to AWS_DEFAULT_REGION; final fallback eu-central-1
- SES_FROM_EMAIL remains a non-secret runtime var
- Other services keep shared instance role; only auth-service uses dedicated role

After merge, CI/CD will apply Terraform and deploy automatically per repo workflows.