### PR TITLE
fix: round 2 — clean Dockerfile on main; S3 editor deploy perms; CE subscriptions read; enforce policy-version-mgmt order

### DIFF
--- a/backend/ebook-service/Dockerfile
+++ b/backend/ebook-service/Dockerfile
@@ -1,9 +1,5 @@
 # Minimal Dockerfile for ebook-service
-<<<<<<< HEAD
 FROM golang:1.23 as builder
-=======
-FROM golang:1.22 as builder
->>>>>>> origin/main
 WORKDIR /app
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -13,11 +9,6 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM gcr.io/distroless/base-debian12
 WORKDIR /
 COPY --from=builder /ebook-service /ebook-service
-<<<<<<< HEAD
 EXPOSE 8084
-=======
-EXPOSE 8080
->>>>>>> origin/main
 USER nonroot:nonroot
 ENTRYPOINT ["/ebook-service"]
-

--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -161,6 +161,7 @@ resource "aws_iam_policy" "apprunner_s3_put_policy" {
   name        = "${var.project}-apprunner-s3-put"
   description = "Allow App Runner instance role to upload objects to product images bucket"
   policy      = data.aws_iam_policy_document.apprunner_s3_put_doc.json
+  depends_on  = [aws_iam_role_policy_attachment.github_actions_policy_version_mgmt_attach]
 }
 
 resource "aws_iam_role_policy_attachment" "apprunner_s3_put_attach" {
@@ -195,13 +196,13 @@ resource "aws_iam_role_policy_attachment" "github_actions_passrole_attach" {
 }
 
 # Read-only Cost Explorer permission for GitHub Actions to detect existing anomaly monitors
-# This enables the workflow step that auto-detects a DIMENSIONAL SERVICE monitor in us-east-1
-# and sets TF_VAR_ce_monitor_arn accordingly (we keep creation disabled by default).
+# and subscriptions in us-east-1.
 data "aws_iam_policy_document" "github_actions_ce_read_doc" {
   statement {
     effect  = "Allow"
     actions = [
-      "ce:GetAnomalyMonitors"
+      "ce:GetAnomalyMonitors",
+      "ce:GetAnomalySubscriptions"
     ]
     resources = ["*"]
   }
@@ -209,13 +210,44 @@ data "aws_iam_policy_document" "github_actions_ce_read_doc" {
 
 resource "aws_iam_policy" "github_actions_ce_read" {
   name        = "${var.project}-github-actions-ce-read"
-  description = "Allow GitHub Actions to read CE anomaly monitors"
+  description = "Allow GitHub Actions to read CE anomaly monitors and subscriptions"
   policy      = data.aws_iam_policy_document.github_actions_ce_read_doc.json
 }
 
 resource "aws_iam_role_policy_attachment" "github_actions_ce_read_attach" {
   role       = "GitHubActions-MadeInWorld-Role"
   policy_arn = aws_iam_policy.github_actions_ce_read.arn
+}
+
+# Allow GitHub Actions to deploy editor site to S3 bucket
+# Grants ListBucket on the bucket and Put/Delete on objects
+
+data "aws_iam_policy_document" "github_actions_editor_deploy_doc" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.editor_site_bucket}"]
+  }
+  statement {
+    effect  = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = ["arn:aws:s3:::${var.editor_site_bucket}/*"]
+  }
+}
+
+resource "aws_iam_policy" "github_actions_editor_deploy" {
+  name        = "${var.project}-github-actions-editor-deploy"
+  description = "Allow GitHub Actions OIDC role to sync editor site to S3"
+  policy      = data.aws_iam_policy_document.github_actions_editor_deploy_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_editor_deploy_attach" {
+  role       = "GitHubActions-MadeInWorld-Role"
+  policy_arn = aws_iam_policy.github_actions_editor_deploy.arn
 }
 
 # Allow GitHub Actions role to manage versions of the apprunner S3 put policy

--- a/terraform/app_runner/variables.tf
+++ b/terraform/app_runner/variables.tf
@@ -91,3 +91,10 @@ variable "enable_auth_ready_canary" {
   type        = bool
   default     = false
 }
+
+# S3 bucket used to host the ebook editor static site (for deploy workflow OIDC role)
+variable "editor_site_bucket" {
+  description = "S3 bucket name for the ebook editor static site"
+  type        = string
+  default     = "madeinworld-ebook-editor-site-eu-central-1"
+}


### PR DESCRIPTION
This PR fixes the new failures observed after #70:

1) Deploy Services to App Runner (ebook-service)
- main contained merge markers in backend/ebook-service/Dockerfile; cleaned to final form (Go 1.23, EXPOSE 8084).

2) Deploy Ebook Editor (S3/CloudFront)
- OIDC role lacked permissions to sync to the editor S3 bucket. Added a GitHub Actions policy allowing `s3:ListBucket` on the bucket and `s3:PutObject/DeleteObject/PutObjectAcl` on objects.
- Introduced variable `editor_site_bucket` (default `madeinworld-ebook-editor-site-eu-central-1`) so the bucket name is configurable and consistent with the workflow fallback.

3) Terraform Apply (App Runner)
- CE permissions: extend GitHubActions role to include `ce:GetAnomalySubscriptions` (required by the provider during create/read).
- IAM policy rotation AccessDenied: enforce ordering so the GitHubActions role has policy-version management permissions before updating the customer-managed policy by adding `depends_on` to `aws_iam_policy.apprunner_s3_put_policy`.

Net effect:
- Docker build for ebook-service will parse correctly and push images.
- Editor deploy workflow can sync to S3 bucket under the OIDC role.
- Terraform no longer fails on CE read or IAM policy version deletion, and App Runner creation won’t fail once the image exists (built by the deploy workflow).
