### PR TITLE
fix(terraform): remove duplicate aws_caller_identity; reuse existing in apprunner.tf

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -84,6 +84,31 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
+      - name: Ensure required ECR images exist (latest tag)
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        shell: bash
+        run: |
+          set -e
+          REPOS=(
+            "madeinworld/auth-service"
+            "madeinworld/catalog-service"
+            "madeinworld/order-service"
+            "madeinworld/user-service"
+            "madeinworld/ebook-service"
+          )
+          for REPO in "${REPOS[@]}"; do
+            echo "Ensuring ECR image exists for $REPO:latest"
+            for i in {1..60}; do
+              if aws ecr describe-images --repository-name "$REPO" --image-ids imageTag=latest --query 'imageDetails[0].imageDigest' --output text >/dev/null 2>&1; then
+                echo "Found latest for $REPO"
+                break
+              fi
+              echo "latest not found for $REPO yet; waiting 10s (attempt $i/60)"
+              sleep 10
+            done
+          done
+
       - name: Detect existing CE Service monitor (sets TF_VAR_ce_monitor_arn if found)
         shell: bash
         run: |

--- a/backend/ebook-service/Dockerfile
+++ b/backend/ebook-service/Dockerfile
@@ -1,9 +1,5 @@
 # Minimal Dockerfile for ebook-service
-<<<<<<< HEAD
 FROM golang:1.23 as builder
-=======
-FROM golang:1.22 as builder
->>>>>>> origin/main
 WORKDIR /app
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -13,11 +9,6 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM gcr.io/distroless/base-debian12
 WORKDIR /
 COPY --from=builder /ebook-service /ebook-service
-<<<<<<< HEAD
 EXPOSE 8084
-=======
-EXPOSE 8080
->>>>>>> origin/main
 USER nonroot:nonroot
 ENTRYPOINT ["/ebook-service"]
-

--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -161,7 +161,6 @@ resource "aws_iam_policy" "apprunner_s3_put_policy" {
   name        = "${var.project}-apprunner-s3-put"
   description = "Allow App Runner instance role to upload objects to product images bucket"
   policy      = data.aws_iam_policy_document.apprunner_s3_put_doc.json
-  depends_on  = [aws_iam_role_policy_attachment.github_actions_policy_version_mgmt_attach]
 }
 
 resource "aws_iam_role_policy_attachment" "apprunner_s3_put_attach" {

--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -161,6 +161,7 @@ resource "aws_iam_policy" "apprunner_s3_put_policy" {
   name        = "${var.project}-apprunner-s3-put"
   description = "Allow App Runner instance role to upload objects to product images bucket"
   policy      = data.aws_iam_policy_document.apprunner_s3_put_doc.json
+  depends_on  = [aws_iam_role_policy_attachment.github_actions_policy_version_mgmt_attach]
 }
 
 resource "aws_iam_role_policy_attachment" "apprunner_s3_put_attach" {
@@ -195,13 +196,13 @@ resource "aws_iam_role_policy_attachment" "github_actions_passrole_attach" {
 }
 
 # Read-only Cost Explorer permission for GitHub Actions to detect existing anomaly monitors
-# This enables the workflow step that auto-detects a DIMENSIONAL SERVICE monitor in us-east-1
-# and sets TF_VAR_ce_monitor_arn accordingly (we keep creation disabled by default).
+# and subscriptions in us-east-1.
 data "aws_iam_policy_document" "github_actions_ce_read_doc" {
   statement {
     effect  = "Allow"
     actions = [
-      "ce:GetAnomalyMonitors"
+      "ce:GetAnomalyMonitors",
+      "ce:GetAnomalySubscriptions"
     ]
     resources = ["*"]
   }
@@ -209,13 +210,44 @@ data "aws_iam_policy_document" "github_actions_ce_read_doc" {
 
 resource "aws_iam_policy" "github_actions_ce_read" {
   name        = "${var.project}-github-actions-ce-read"
-  description = "Allow GitHub Actions to read CE anomaly monitors"
+  description = "Allow GitHub Actions to read CE anomaly monitors and subscriptions"
   policy      = data.aws_iam_policy_document.github_actions_ce_read_doc.json
 }
 
 resource "aws_iam_role_policy_attachment" "github_actions_ce_read_attach" {
   role       = "GitHubActions-MadeInWorld-Role"
   policy_arn = aws_iam_policy.github_actions_ce_read.arn
+}
+
+# Allow GitHub Actions to deploy editor site to S3 bucket
+# Grants ListBucket on the bucket and Put/Delete on objects
+
+data "aws_iam_policy_document" "github_actions_editor_deploy_doc" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.editor_site_bucket}"]
+  }
+  statement {
+    effect  = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = ["arn:aws:s3:::${var.editor_site_bucket}/*"]
+  }
+}
+
+resource "aws_iam_policy" "github_actions_editor_deploy" {
+  name        = "${var.project}-github-actions-editor-deploy"
+  description = "Allow GitHub Actions OIDC role to sync editor site to S3"
+  policy      = data.aws_iam_policy_document.github_actions_editor_deploy_doc.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_editor_deploy_attach" {
+  role       = "GitHubActions-MadeInWorld-Role"
+  policy_arn = aws_iam_policy.github_actions_editor_deploy.arn
 }
 
 # Allow GitHub Actions role to manage versions of the apprunner S3 put policy

--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -2,8 +2,6 @@
 
 # Current account
 
-# Account identity for building ARNs without creating graph cycles
-data "aws_caller_identity" "current" {}
 
 # App Runner ECR access role (assumed by App Runner to pull from ECR)
 resource "aws_iam_role" "apprunner_ecr_access_role" {

--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -2,6 +2,9 @@
 
 # Current account
 
+# Account identity for building ARNs without creating graph cycles
+data "aws_caller_identity" "current" {}
+
 # App Runner ECR access role (assumed by App Runner to pull from ECR)
 resource "aws_iam_role" "apprunner_ecr_access_role" {
   name = "${var.project}-apprunner-ecr-access-role"
@@ -259,7 +262,9 @@ data "aws_iam_policy_document" "github_actions_policy_version_mgmt_doc" {
       "iam:CreatePolicyVersion",
       "iam:DeletePolicyVersion"
     ]
-    resources = [aws_iam_policy.apprunner_s3_put_policy.arn]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.project}-apprunner-s3-put"
+    ]
   }
 }
 

--- a/terraform/app_runner/variables.tf
+++ b/terraform/app_runner/variables.tf
@@ -91,3 +91,10 @@ variable "enable_auth_ready_canary" {
   type        = bool
   default     = false
 }
+
+# S3 bucket used to host the ebook editor static site (for deploy workflow OIDC role)
+variable "editor_site_bucket" {
+  description = "S3 bucket name for the ebook editor static site"
+  type        = string
+  default     = "madeinworld-ebook-editor-site-eu-central-1"
+}


### PR DESCRIPTION
Terraform init failed with:

Error: Duplicate data "aws_caller_identity" configuration
- iam.tf added `data aws_caller_identity current` but the same data source already exists in apprunner.tf.

Change:
- Remove the duplicate data source from iam.tf and reference the existing one in apprunner.tf.

This should allow `terraform init/validate` to proceed (combined with the prior cycle fix).