### PR TITLE
fix(terraform): remove duplicate aws_caller_identity in iam.tf; use existing in apprunner.tf

### DIFF
--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -3,7 +3,6 @@
 # Current account
 
 # Account identity for building ARNs without creating graph cycles
-data "aws_caller_identity" "current" {}
 
 # App Runner ECR access role (assumed by App Runner to pull from ECR)
 resource "aws_iam_role" "apprunner_ecr_access_role" {


### PR DESCRIPTION
Terraform init on main failed due to duplicate data source:

Error: Duplicate data "aws_caller_identity" configuration
- iam.tf declared data.aws_caller_identity.current but apprunner.tf already declares it.

This PR removes the duplicate from iam.tf and relies on the existing declaration in apprunner.tf. Combined with the previous cycle fix, `terraform init/validate` should now proceed.