### PR TITLE
ci(terraform): two-phase apply for IAM policy-version perms; fix deploy to prefer non-deleted newest service

### DIFF
--- a/.github/workflows/deploy-app-runner.yml
+++ b/.github/workflows/deploy-app-runner.yml
@@ -63,9 +63,19 @@ jobs:
           SERVICE_NAME: madeinworld-${{ matrix.service }}-dev
         run: |
           set -e
-          ARN=$(aws apprunner list-services --query "ServiceSummaryList[?ServiceName=='$SERVICE_NAME'].ServiceArn | [0]" --output text)
+          echo "Resolving ARN for $SERVICE_NAME (prefer non-deleted, newest)"
+          for i in {1..60}; do
+            ARN=$(aws apprunner list-services \
+              --query "ServiceSummaryList[?ServiceName=='$SERVICE_NAME' && Status!='DELETED' && Status!='DELETE_IN_PROGRESS'] | sort_by(@,&CreatedAt)[-1].ServiceArn" \
+              --output text)
+            if [ -n "$ARN" ] && [ "$ARN" != "None" ]; then
+              break
+            fi
+            echo "Service not yet available; retrying (attempt $i/60)"
+            sleep 10
+          done
           if [ -z "$ARN" ] || [ "$ARN" = "None" ]; then
-            echo "No App Runner service found for $SERVICE_NAME" >&2
+            echo "No active App Runner service found for $SERVICE_NAME" >&2
             exit 1
           fi
           echo "Service ARN: $ARN"

--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -132,7 +132,22 @@ jobs:
         run: |
           terraform state rm 'aws_ce_anomaly_subscription.cloudwatch_alerts[0]' || true
 
-      - name: Terraform Plan
+      - name: Terraform Plan (initial)
+        run: terraform plan -input=false -no-color -parallelism=1 -lock-timeout=5m
+
+      - name: Terraform Apply (policy version mgmt only)
+        run: |
+          terraform apply -input=false -auto-approve -no-color -parallelism=1 -lock-timeout=5m \
+            -target=aws_iam_policy.github_actions_policy_version_mgmt \
+            -target=aws_iam_role_policy_attachment.github_actions_policy_version_mgmt_attach
+
+      - name: Reconfigure AWS credentials (refresh session)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Terraform Plan (full)
         run: terraform plan -input=false -no-color -parallelism=1 -lock-timeout=5m
 
       - name: Terraform Apply (all resources)


### PR DESCRIPTION
Terraform Apply failure root cause:
- AccessDenied on iam:DeletePolicyVersion when updating customer-managed policy `madeinworld-apprunner-s3-put`.
- Even though this run creates and attaches a policy with `iam:DeletePolicyVersion` to the OIDC role, the current assumed role session cannot gain new permissions mid-run.

Fixes:
1) Apply IAM policy-version management first, then re-assume the role, then perform full plan/apply.
   - Add a targeted apply for:
     - aws_iam_policy.github_actions_policy_version_mgmt
     - aws_iam_role_policy_attachment.github_actions_policy_version_mgmt_attach
   - Re-run aws-actions/configure-aws-credentials to refresh the session with new perms
   - Then run full plan/apply

Deploy Services failure root cause:
- The workflow sometimes latched onto a DELETED service ARN after Terraform replaced the service.

Fix:
- Change ARN resolution to select the newest non-deleted service by name using JMES path filter and sort_by(CreatedAt).
- Add retries while waiting for the new service ARN to become available.

These changes unblock both workflows reliably.