### PR TITLE
ci(terraform): quiet CE state removal when resource absent

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -129,8 +129,18 @@ jobs:
           fi
 
       - name: Remove CE subscription from state (best effort)
+        shell: bash
         run: |
-          terraform state rm 'aws_ce_anomaly_subscription.cloudwatch_alerts[0]' || true
+          set +e
+          MATCHES=$(terraform state list | grep '^aws_ce_anomaly_subscription\.cloudwatch_alerts' || true)
+          if [ -z "$MATCHES" ]; then
+            echo "No CE subscription instances found in state; skipping removal"
+          else
+            echo "Removing CE subscription instances from state:"; echo "$MATCHES"
+            while IFS= read -r addr; do
+              terraform state rm "$addr" || true
+            done <<< "$MATCHES"
+          fi
 
       - name: Terraform Plan (initial)
         run: terraform plan -input=false -no-color -parallelism=1 -lock-timeout=5m


### PR DESCRIPTION
Avoid noisy error output when the CE subscription resource isn’t present in state. The previous best‑effort `terraform state rm` could print an error and (in some shells) return a non‑zero exit.

Change:
- Only attempt `terraform state rm` if `terraform state list` finds any `aws_ce_anomaly_subscription.cloudwatch_alerts*` addresses. Remove all matches in a loop, otherwise print a friendly skip message.

This keeps logs clean while retaining the safety net behavior.