### PR TITLE
feat(ce): re-enable CE anomaly subscription; add write perms; remove state-rm

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -59,7 +59,7 @@ jobs:
           echo "TF_VAR_create_ce_anomaly_monitor=false" >> $GITHUB_ENV
           # Disable the canary IAM policy attachments by default
           echo "TF_VAR_enable_auth_ready_canary=false" >> $GITHUB_ENV
-          echo "TF_VAR_enable_ce_anomaly_subscription=false" >> $GITHUB_ENV
+          echo "TF_VAR_enable_ce_anomaly_subscription=true" >> $GITHUB_ENV
 
 
 
@@ -126,20 +126,6 @@ jobs:
             echo "No existing CE SERVICE monitor found; Terraform will NOT create one by default."
             echo "TF_VAR_create_ce_anomaly_monitor=false" >> $GITHUB_ENV
 
-          fi
-
-      - name: Remove CE subscription from state (best effort)
-        shell: bash
-        run: |
-          set +e
-          MATCHES=$(terraform state list | grep '^aws_ce_anomaly_subscription\.cloudwatch_alerts' || true)
-          if [ -z "$MATCHES" ]; then
-            echo "No CE subscription instances found in state; skipping removal"
-          else
-            echo "Removing CE subscription instances from state:"; echo "$MATCHES"
-            while IFS= read -r addr; do
-              terraform state rm "$addr" || true
-            done <<< "$MATCHES"
           fi
 
       - name: Terraform Plan (initial)

--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -129,8 +129,18 @@ jobs:
           fi
 
       - name: Remove CE subscription from state (best effort)
+        shell: bash
         run: |
-          terraform state rm 'aws_ce_anomaly_subscription.cloudwatch_alerts[0]' || true
+          set +e
+          MATCHES=$(terraform state list | grep '^aws_ce_anomaly_subscription\.cloudwatch_alerts' || true)
+          if [ -z "$MATCHES" ]; then
+            echo "No CE subscription instances found in state; skipping removal"
+          else
+            echo "Removing CE subscription instances from state:"; echo "$MATCHES"
+            while IFS= read -r addr; do
+              terraform state rm "$addr" || true
+            done <<< "$MATCHES"
+          fi
 
       - name: Terraform Plan (initial)
         run: terraform plan -input=false -no-color -parallelism=1 -lock-timeout=5m

--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -204,7 +204,10 @@ data "aws_iam_policy_document" "github_actions_ce_read_doc" {
     effect  = "Allow"
     actions = [
       "ce:GetAnomalyMonitors",
-      "ce:GetAnomalySubscriptions"
+      "ce:GetAnomalySubscriptions",
+      "ce:CreateAnomalySubscription",
+      "ce:UpdateAnomalySubscription",
+      "ce:DeleteAnomalySubscription"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
This PR re-enables Cost Explorer anomaly subscription management and removes the temporary state-rm workaround.

Changes:
- CI: Set `TF_VAR_enable_ce_anomaly_subscription=true` so Terraform manages the CE anomaly subscription again (still requires an existing SERVICE monitor; creation remains gated by `TF_VAR_create_ce_anomaly_monitor=false`).
- CI: Remove the `terraform state rm` step for CE subscription since it’s no longer needed.
- IAM: Extend the GitHub OIDC role policy to include CE subscription write actions (`Create/Update/DeleteAnomalySubscription`) alongside existing read actions. This allows Terraform to create/update/delete the subscription in us-east-1.

Notes:
- This keeps monitor creation off by default to avoid account-wide limits; if you want Terraform to create the monitor too, I can flip `TF_VAR_create_ce_anomaly_monitor=true` in CI.
- Two-phase IAM apply + re-assume from PR #77 remains, so permission propagation is handled.
