### PR TITLE
ci(terraform): auto-import existing CE subscription to avoid duplicate-name error

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -143,6 +143,28 @@ jobs:
           role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+
+      - name: Import existing CE subscription if it exists (idempotent)
+        shell: bash
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set +e
+          # Look up subscription by name in us-east-1
+          SUB_ARN=$(aws ce get-anomaly-subscriptions --region us-east-1 \
+            --query "Subscriptions[?Name=='cloudwatch-anomaly-alerts'].Arn | [0]" --output text 2>/dev/null || true)
+          echo "Existing CE subscription ARN: $SUB_ARN"
+          if [ -n "$SUB_ARN" ] && [ "$SUB_ARN" != "None" ]; then
+            if terraform state list | grep -q '^aws_ce_anomaly_subscription\.cloudwatch_alerts\[0\]$'; then
+              echo "Terraform already has CE subscription in state; skipping import"
+            else
+              echo "Importing CE subscription into Terraform state"
+              terraform import 'aws_ce_anomaly_subscription.cloudwatch_alerts[0]' "$SUB_ARN" || true
+            fi
+          else
+            echo "No existing CE subscription found; Terraform will create it if enabled"
+          fi
+
       - name: Terraform Plan (full)
         run: terraform plan -input=false -no-color -parallelism=1 -lock-timeout=5m
 


### PR DESCRIPTION
Terraform Apply failed with 400 ValidationException: "Cannot create a subscription with the same subscription name as an existing subscription" when re-enabling CE anomaly subscription management.

Fix:
- Before the full plan/apply, look up a CE subscription named `cloudwatch-anomaly-alerts` in us-east-1 via AWS CLI.
- If found, import it into Terraform state as `aws_ce_anomaly_subscription.cloudwatch_alerts[0]` (only if not already present in state).
- Then proceed with plan/apply. If not found, Terraform creates it as usual.

This keeps the single subscription authoritative in Terraform without changing any resource names or creating duplicates.