### PR TITLE
ci(terraform): correct CE import query (AnomalySubscriptions/SubscriptionName)

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -152,7 +152,7 @@ jobs:
           set +e
           # Look up subscription by name in us-east-1
           SUB_ARN=$(aws ce get-anomaly-subscriptions --region us-east-1 --max-results 100 \
-            --query "Subscriptions[?Name=='cloudwatch-anomaly-alerts'].SubscriptionArn | [0]" --output text 2>/dev/null || true)
+            --query "AnomalySubscriptions[?SubscriptionName=='cloudwatch-anomaly-alerts'].SubscriptionArn | [0]" --output text 2>/dev/null || true)
           echo "Existing CE subscription ARN: $SUB_ARN"
           if [ -n "$SUB_ARN" ] && [ "$SUB_ARN" != "None" ]; then
             if terraform state list | grep -q '^aws_ce_anomaly_subscription\.cloudwatch_alerts\[0\]$'; then


### PR DESCRIPTION
Follow-up to #81.

After #81 merged, Terraform Apply still failed because the import step could not find the existing CE anomaly subscription by name. The Cost Explorer API response shape uses `AnomalySubscriptions[].SubscriptionName` and `AnomalySubscriptions[].SubscriptionArn`.

Change:
- Update the pre-plan import step to query:
  `AnomalySubscriptions[?SubscriptionName=='cloudwatch-anomaly-alerts'].SubscriptionArn | [0]`
  with `--max-results 100`.

Effect:
- If a subscription with that name already exists, we import it into state before plan/apply, preventing the duplicate-name 400 during creation.

This PR contains only the workflow fix in `.github/workflows/terraform-app-runner-apply.yml`.