### PR TITLE
iam: grant ce:ListTagsForResource to GitHub Actions role for CE import

### DIFF
--- a/terraform/app_runner/iam.tf
+++ b/terraform/app_runner/iam.tf
@@ -205,6 +205,7 @@ data "aws_iam_policy_document" "github_actions_ce_read_doc" {
     actions = [
       "ce:GetAnomalyMonitors",
       "ce:GetAnomalySubscriptions",
+      "ce:ListTagsForResource",
       "ce:CreateAnomalySubscription",
       "ce:UpdateAnomalySubscription",
       "ce:DeleteAnomalySubscription"


### PR DESCRIPTION
Fix Terraform Apply failure during CE subscription import.

Problem
- Import now finds the existing subscription and starts `terraform import` successfully, but fails while refreshing the imported resource because the role lacks `ce:ListTagsForResource`.
- Logs show: `AccessDeniedException: ... is not authorized to perform: ce:ListTagsForResource`.

Change
- Add `ce:ListTagsForResource` to the GitHub Actions CE policy in `terraform/app_runner/iam.tf`.

Effect
- `terraform import` can refresh/read the imported resource and complete.
- After import, plan/apply will not try to create a duplicate and the run should pass.
