### PR TITLE
ci(terraform): ensure CE import runs just before final apply (safety)

### DIFF
--- a/.github/workflows/terraform-app-runner-apply.yml
+++ b/.github/workflows/terraform-app-runner-apply.yml
@@ -168,6 +168,27 @@ jobs:
       - name: Terraform Plan (full)
         run: terraform plan -input=false -no-color -parallelism=1 -lock-timeout=5m
 
+
+      - name: Ensure CE subscription is imported (safety before apply)
+        shell: bash
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          set +e
+          SUB_ARN=$(aws ce get-anomaly-subscriptions --region us-east-1 --max-results 100 \
+            --query "AnomalySubscriptions[?SubscriptionName=='cloudwatch-anomaly-alerts'].SubscriptionArn | [0]" --output text 2>/dev/null || true)
+          echo "Safety import check — Existing CE subscription ARN: $SUB_ARN"
+          if [ -n "$SUB_ARN" ] && [ "$SUB_ARN" != "None" ]; then
+            if terraform state list | grep -q '^aws_ce_anomaly_subscription\.cloudwatch_alerts\[0\]$'; then
+              echo "Already in state; skipping safety import"
+            else
+              echo "Importing CE subscription into Terraform state (safety pass)"
+              terraform import 'aws_ce_anomaly_subscription.cloudwatch_alerts[0]' "$SUB_ARN" || true
+            fi
+          else
+            echo "No existing CE subscription found during safety check; continuing"
+          fi
+
       - name: Terraform Apply (all resources)
         run: |
           terraform apply -input=false -auto-approve -no-color -parallelism=1 -lock-timeout=5m


### PR DESCRIPTION
Context: CE subscription import is now working with the correct query and permissions (#82, #83). However, in some runs the import step output didn’t appear before the final apply, and Terraform still attempted to create a duplicate.

Change:
- Add a second, idempotent import step right before the final `terraform apply` to guarantee the subscription is imported into state.

Details:
- Looks up `AnomalySubscriptions[?SubscriptionName=='cloudwatch-anomaly-alerts'].SubscriptionArn | [0]` in `us-east-1`.
- If found and not in state, calls `terraform import aws_ce_anomaly_subscription.cloudwatch_alerts[0]`.
- If already in state or not found, continues without failing.

Effect:
- Ensures the existing subscription is present in state immediately prior to apply, preventing duplicate-name creation errors in intermittent cases.
