### PR TITLE
Edge proxy: allow X-Require-Existing and X-Require-Role in CORS headers (fix ebook editor login preflight)

### DIFF
--- a/workers/edge-proxy/src/index.js
+++ b/workers/edge-proxy/src/index.js
@@ -101,7 +101,7 @@ function corsHeaders(origin) {
   h.set('Access-Control-Allow-Origin', origin || '*');
   h.set('Vary', 'Origin');
   h.set('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
-  h.set('Access-Control-Allow-Headers', 'Origin,Content-Type,Accept,Authorization,X-Correlation-Id,X-Admin-Request');
+  h.set('Access-Control-Allow-Headers', 'Origin,Content-Type,Accept,Authorization,X-Correlation-Id,X-Admin-Request,X-Require-Existing,X-Require-Role,X-CSRF-Token');
   h.set('Access-Control-Allow-Credentials', 'true');
   return h;
 }


### PR DESCRIPTION
Fix CORS preflight for ebook-editor login by allowing the headers used to enforce existing user + required role.

Changes:
- workers/edge-proxy/src/index.js: add X-Require-Existing, X-Require-Role (and X-CSRF-Token) to Access-Control-Allow-Headers in corsHeaders().

Why:
- The ebook editor sends these headers to auth-service. Browser OPTIONS preflight was blocked at the Worker because they were not allowed, leading to "Failed to send code" in the UI. cURL worked because it bypasses preflight.

Deployment:
- Merging to main will trigger .github/workflows/deploy-worker.yml to publish the Worker via wrangler.

Risk: Low. Only expands allowed request headers for CORS; no functional routing change.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author