### PR TITLE
Ops: fix CloudFront behavior creation (set SmoothStreaming=false)

### DIFF
--- a/.github/workflows/ops-cloudfront-ensure-index-behavior.yml
+++ b/.github/workflows/ops-cloudfront-ensure-index-behavior.yml
@@ -89,6 +89,7 @@ jobs:
                 ViewerProtocolPolicy: "redirect-to-https",
                 AllowedMethods: { Quantity: 7, Items: ["GET","HEAD","OPTIONS","PUT","PATCH","POST","DELETE"], CachedMethods: { Quantity: 2, Items: ["GET","HEAD"] } },
                 Compress: true,
+                SmoothStreaming: false,
                 CachePolicyId: $mid
               }]))
               | (.CacheBehaviors.Quantity = ((.CacheBehaviors.Items|length) // 0))


### PR DESCRIPTION
Set SmoothStreaming=false on the new /index.html cache behavior to satisfy CloudFront schema. This should fix the "The parameter SmoothStreaming flag is missing" error in the ops workflow.

After merge, we can re-run the workflow "Ensure CloudFront /index.html behavior (CachingDisabled)".

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author